### PR TITLE
improve handling of multi-project builds by implementing Dokka Module config

### DIFF
--- a/modules/dokkatoo-base-plugin/src/main/kotlin/DokkatooExtension.kt
+++ b/modules/dokkatoo-base-plugin/src/main/kotlin/DokkatooExtension.kt
@@ -15,6 +15,9 @@ abstract class DokkatooExtension: ExtensionAware {
   /** Directory into which [DokkaPublication]s will be produced */
   abstract val dokkatooPublicationDirectory: DirectoryProperty
 
+  /** Directory into which Dokka Modules will be produced */
+  abstract val dokkatooModuleDirectory: DirectoryProperty
+
   abstract val dokkatooConfigurationsDirectory: DirectoryProperty
 
   /** Default Dokkatoo cache directory */

--- a/modules/dokkatoo-base-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
+++ b/modules/dokkatoo-base-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
@@ -5,7 +5,7 @@ import com.android.build.gradle.api.LibraryVariant
 import dev.adamko.dokkatoo.DokkatooExtension
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import dev.adamko.dokkatoo.internal.not
-import dev.adamko.dokkatoo.tasks.DokkatooCreateConfigurationTask
+import dev.adamko.dokkatoo.tasks.DokkatooPrepareParametersTask
 import java.io.File
 import javax.inject.Inject
 import org.gradle.api.Plugin
@@ -83,7 +83,7 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
 
       // TODO remove this - tasks shouldn't be configured directly, instead source sets
       //      should be added to the Dokka extension, which will then create and configure appropriate tasks
-      project.tasks.withType<DokkatooCreateConfigurationTask>().configureEach {
+      project.tasks.withType<DokkatooPrepareParametersTask>().configureEach {
         dokkaSourceSets.configureEach {
           suppress.convention(
             todoSourceSetName.flatMap {

--- a/modules/dokkatoo-base-plugin/src/main/kotlin/distibutions/DokkatooConfigurationAttributes.kt
+++ b/modules/dokkatoo-base-plugin/src/main/kotlin/distibutions/DokkatooConfigurationAttributes.kt
@@ -23,11 +23,12 @@ abstract class DokkatooConfigurationAttributes @Inject constructor(
 //    val dokkaBaseUsage: Usage = objects.named("org.jetbrains.dokka")
   val dokkatooBaseUsage: DokkatooBaseAttribute = objects.named("dokkatoo")
 
-  /** for [Configuration]s that provide or consume Dokka configuration files */
-  val dokkaConfiguration: DokkatooCategoryAttribute = objects.named("configuration")
+  /** for [Configuration]s that provide or consume Dokka parameter files */
+  val dokkaParameters: DokkatooCategoryAttribute = objects.named("generator-parameters")
 
   /** for [Configuration]s that provide or consume Dokka module descriptor files */
   val dokkaModuleDescriptors: DokkatooCategoryAttribute = objects.named("module-descriptor")
+  val dokkaModuleSource: DokkatooCategoryAttribute = objects.named("module-source")
 
   val dokkaGeneratorClasspath: DokkatooCategoryAttribute = objects.named("generator-classpath")
 

--- a/modules/dokkatoo-base-plugin/src/main/kotlin/distibutions/DokkatooFormatGradleConfigurations.kt
+++ b/modules/dokkatoo-base-plugin/src/main/kotlin/distibutions/DokkatooFormatGradleConfigurations.kt
@@ -15,10 +15,20 @@ internal data class DokkatooFormatGradleConfigurations(
 //    val dokkaConsumer: NamedDomainObjectProvider<Configuration>,
 
 
-  /** Fetch Dokka Configuration files from other subprojects */
-  val dokkaConfigurationsConsumer: NamedDomainObjectProvider<Configuration>,
-  /** Provide Dokka Configurations files to other subprojects */
-  val dokkaConfigurationsElements: NamedDomainObjectProvider<Configuration>,
+  /** Fetch Dokka Parameter files from other subprojects */
+  val dokkaParametersConsumer: NamedDomainObjectProvider<Configuration>,
+  /** Provide Dokka Parameter files to other subprojects */
+  val dokkaParametersOutgoing: NamedDomainObjectProvider<Configuration>,
+
+  /** Fetch Dokka Module Descriptor files from other subprojects */
+  val dokkaModuleDescriptorsConsumer: NamedDomainObjectProvider<Configuration>,
+  /** Provide Dokka Module Descriptor files to other subprojects */
+  val dokkaModuleDescriptorsOutgoing: NamedDomainObjectProvider<Configuration>,
+
+  /** Fetch Dokka Module Source Outputs from other subprojects */
+  val dokkaModuleSourceOutputsConsumer: NamedDomainObjectProvider<Configuration>,
+  /** Provide Dokka Module Source Outputs to other subprojects */
+  val dokkaModuleSourceOutputsOutgoing: NamedDomainObjectProvider<Configuration>,
 
 
   /**
@@ -47,4 +57,10 @@ internal data class DokkatooFormatGradleConfigurations(
    * the dependencies are computed automatically.
    */
   val dokkaPluginsIntransitiveClasspath: NamedDomainObjectProvider<Configuration>,
+
+
+  /**
+   * Provides Dokka plugins to other subprojects.
+   */
+  val dokkaPluginsClasspathOutgoing: NamedDomainObjectProvider<Configuration>,
 )

--- a/modules/dokkatoo-base-plugin/src/main/kotlin/dokka/DokkaPublication.kt
+++ b/modules/dokkatoo-base-plugin/src/main/kotlin/dokka/DokkaPublication.kt
@@ -1,13 +1,19 @@
 package dev.adamko.dokkatoo.dokka
 
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_CONFIGURATIONS
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_CONFIGURATION_ELEMENTS
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_MODULE_DESCRIPTORS_CONSUMER
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_MODULE_DESCRIPTOR_PROVIDER
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_MODULE_SOURCE_OUTPUT_CONSUMER
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_MODULE_SOURCE_OUTPUT_PROVIDER
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_PARAMETERS
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_PARAMETERS_OUTGOING
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKA_GENERATOR_CLASSPATH
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKA_PLUGINS_CLASSPATH
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKA_PLUGINS_CLASSPATH_OUTGOING
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKA_PLUGINS_INTRANSITIVE_CLASSPATH
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.CREATE_CONFIGURATION
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.CREATE_MODULE_CONFIGURATION
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.GENERATE
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.GENERATE_MODULE
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.GENERATE_PUBLICATION
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.PREPARE_MODULE_DESCRIPTOR
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.PREPARE_PARAMETERS
 import dev.adamko.dokkatoo.dokka.parameters.DokkaParametersGradleBuilder
 import java.io.Serializable
 import javax.inject.Inject
@@ -39,29 +45,36 @@ abstract class DokkaPublication @Inject constructor(
   @get:Input
   abstract val enabled: Property<Boolean>
 
+  @get:Nested
+  abstract val dokkaConfiguration: DokkaParametersGradleBuilder
+
   @Internal
   val taskNames = TaskNames()
 
   @Internal
   val configurationNames = ConfigurationNames()
 
+  private fun String.formatSuffix() = this + formatName.capitalize()
+
   inner class TaskNames : Serializable {
-    val generate: String = GENERATE + formatName.capitalize()
-    val createConfiguration: String = CREATE_CONFIGURATION + formatName.capitalize()
-    val createModuleConfiguration: String =
-      CREATE_MODULE_CONFIGURATION + formatName.capitalize()
+    val generatePublication = GENERATE_PUBLICATION.formatSuffix()
+    val generateModule = GENERATE_MODULE.formatSuffix()
+    val prepareParameters = PREPARE_PARAMETERS.formatSuffix()
+    val prepareModuleDescriptor = PREPARE_MODULE_DESCRIPTOR.formatSuffix()
   }
+
+  // TODO rename 'outgoing' or 'provider' to 'shared'?
 
   inner class ConfigurationNames : Serializable {
-    val dokkaConfigurations: String = DOKKATOO_CONFIGURATIONS + formatName.capitalize()
-    val dokkaConfigurationElements: String = DOKKATOO_CONFIGURATION_ELEMENTS + formatName.capitalize()
-    val dokkaGeneratorClasspath: String = DOKKA_GENERATOR_CLASSPATH + formatName.capitalize()
-    val dokkaPluginsClasspath: String = DOKKA_PLUGINS_CLASSPATH + formatName.capitalize()
-    val dokkaPluginsIntransitiveClasspath: String =
-      DOKKA_PLUGINS_INTRANSITIVE_CLASSPATH + formatName.capitalize()
+    val dokkaParametersConsumer: String = DOKKATOO_PARAMETERS.formatSuffix()
+    val dokkaParametersOutgoing: String = DOKKATOO_PARAMETERS_OUTGOING.formatSuffix()
+    val moduleDescriptors = DOKKATOO_MODULE_DESCRIPTORS_CONSUMER.formatSuffix()
+    val moduleDescriptorsOutgoing = DOKKATOO_MODULE_DESCRIPTOR_PROVIDER.formatSuffix()
+    val moduleSourceOutputConsumer = DOKKATOO_MODULE_SOURCE_OUTPUT_CONSUMER.formatSuffix()
+    val moduleSourceOutputOutgoing = DOKKATOO_MODULE_SOURCE_OUTPUT_PROVIDER.formatSuffix()
+    val dokkaGeneratorClasspath = DOKKA_GENERATOR_CLASSPATH.formatSuffix()
+    val dokkaPluginsClasspath = DOKKA_PLUGINS_CLASSPATH.formatSuffix()
+    val dokkaPluginsIntransitiveClasspath = DOKKA_PLUGINS_INTRANSITIVE_CLASSPATH.formatSuffix()
+    val dokkaPluginsClasspathOutgoing = DOKKA_PLUGINS_CLASSPATH_OUTGOING.formatSuffix()
   }
-
-
-  @get:Nested
-  abstract val dokkaConfiguration: DokkaParametersGradleBuilder
 }

--- a/modules/dokkatoo-base-plugin/src/main/kotlin/dokka/parameters/DokkaParametersKxs.kt
+++ b/modules/dokkatoo-base-plugin/src/main/kotlin/dokka/parameters/DokkaParametersKxs.kt
@@ -48,6 +48,7 @@ data class DokkaParametersKxs(
   val modulesKxs: List<DokkaModuleDescriptionKxs>,
 ) : DokkaConfiguration, Named {
 
+
   override val modules: List<DokkaConfiguration.DokkaModuleDescription> =
     modulesKxs.map { it.toCoreModel(outputDir) }
 

--- a/modules/dokkatoo-base-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-base-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -86,7 +86,6 @@ abstract class DokkatooFormatPlugin @Inject constructor(
         version.map { v -> create("$this:$v") }
 
       with(dokkatooExtension.versions) {
-        dokkaPlugin("org.jetbrains:markdown-jvm" version jetbrainsMarkdown)
 
         dokkaPlugin(dokka("kotlin-analysis-intellij"))
         dokkaPlugin(dokka("dokka-base"))
@@ -98,6 +97,8 @@ abstract class DokkatooFormatPlugin @Inject constructor(
         dokkaPlugin("org.freemarker:freemarker" version freemarker)
 
         dokkaGenerator(dokka("dokka-core"))
+        // TODO why does this need a -jvm suffix?
+        dokkaGenerator("org.jetbrains:markdown-jvm" version jetbrainsMarkdown)
       }
     }
   }

--- a/modules/dokkatoo-base-plugin/src/main/kotlin/tasks/DokkatooPrepareModuleDescriptorTask.kt
+++ b/modules/dokkatoo-base-plugin/src/main/kotlin/tasks/DokkatooPrepareModuleDescriptorTask.kt
@@ -13,9 +13,11 @@ import org.gradle.api.tasks.PathSensitivity.RELATIVE
 
 /**
  * Produces a Dokka Configuration that describes a single module of a multimodule Dokka configuration.
+ *
+ * @see dev.adamko.dokkatoo.dokka.parameters.DokkaParametersKxs.DokkaModuleDescriptionKxs
  */
 @CacheableTask
-abstract class DokkatooModuleConfigurationTask @Inject constructor(
+abstract class DokkatooPrepareModuleDescriptorTask @Inject constructor(
   private val layout: ProjectLayout,
 ) : DokkatooTask() {
 
@@ -49,7 +51,7 @@ abstract class DokkatooModuleConfigurationTask @Inject constructor(
   abstract val includes: ConfigurableFileCollection
 
   @get:OutputFile
-  abstract val dokkaModuleConfigurationJson: RegularFileProperty
+  abstract val dokkaModuleDescriptorJson: RegularFileProperty
 
   @TaskAction
   fun generateModuleConfiguration() {
@@ -69,6 +71,6 @@ abstract class DokkatooModuleConfigurationTask @Inject constructor(
 
     logger.info("encodedModuleDesc: $encodedModuleDesc")
 
-    dokkaModuleConfigurationJson.get().asFile.writeText(encodedModuleDesc)
+    dokkaModuleDescriptorJson.get().asFile.writeText(encodedModuleDesc)
   }
 }

--- a/modules/dokkatoo-base-plugin/src/test/kotlin/DokkatooPluginTest.kt
+++ b/modules/dokkatoo-base-plugin/src/test/kotlin/DokkatooPluginTest.kt
@@ -1,6 +1,6 @@
 package dev.adamko.dokkatoo
 
-import dev.adamko.dokkatoo.tasks.DokkatooCreateConfigurationTask
+import dev.adamko.dokkatoo.tasks.DokkatooPrepareParametersTask
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 import org.gradle.api.Action
@@ -32,7 +32,7 @@ class DokkatooPluginTest {
     val project = ProjectBuilder.builder().build()
     project.plugins.apply("dev.adamko.dokkatoo")
 
-    project.tasks.withType<DokkatooCreateConfigurationTask>().configureEach(action {
+    project.tasks.withType<DokkatooPrepareParametersTask>().configureEach(action {
       dokkaSourceSets.create("Blah", action {
 
         sourceSetScope.set("moduleName")

--- a/modules/dokkatoo-base-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
+++ b/modules/dokkatoo-base-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
@@ -25,16 +25,24 @@ class DokkatooPluginFunctionalTest {
     build.output.invariantNewlines() shouldContain /* language=text */ """
       |Dokkatoo tasks
       |--------------
-      |createDokkatooConfiguration - Runs all Dokkatoo Create Configuration tasks
-      |createDokkatooConfigurationGfm - Creates Dokka Configuration for executing the Dokka Generator for the gfm publication
-      |createDokkatooConfigurationHtml - Creates Dokka Configuration for executing the Dokka Generator for the html publication
-      |createDokkatooConfigurationJavadoc - Creates Dokka Configuration for executing the Dokka Generator for the javadoc publication
-      |createDokkatooConfigurationJekyll - Creates Dokka Configuration for executing the Dokka Generator for the jekyll publication
       |dokkatooGenerate - Runs all Dokkatoo Generate tasks
-      |dokkatooGenerateGfm - Executes the Dokka Generator, producing the gfm publication
-      |dokkatooGenerateHtml - Executes the Dokka Generator, producing the html publication
-      |dokkatooGenerateJavadoc - Executes the Dokka Generator, producing the javadoc publication
-      |dokkatooGenerateJekyll - Executes the Dokka Generator, producing the jekyll publication
+      |dokkatooGenerateModuleGfm - Executes the Dokka Generator, generating a gfm module
+      |dokkatooGenerateModuleHtml - Executes the Dokka Generator, generating a html module
+      |dokkatooGenerateModuleJavadoc - Executes the Dokka Generator, generating a javadoc module
+      |dokkatooGenerateModuleJekyll - Executes the Dokka Generator, generating a jekyll module
+      |dokkatooGeneratePublicationGfm - Executes the Dokka Generator, generating the gfm publication
+      |dokkatooGeneratePublicationHtml - Executes the Dokka Generator, generating the html publication
+      |dokkatooGeneratePublicationJavadoc - Executes the Dokka Generator, generating the javadoc publication
+      |dokkatooGeneratePublicationJekyll - Executes the Dokka Generator, generating the jekyll publication
+      |prepareDokkatooModuleDescriptorGfm - Prepares the Dokka Module Descriptor JSON
+      |prepareDokkatooModuleDescriptorHtml - Prepares the Dokka Module Descriptor JSON
+      |prepareDokkatooModuleDescriptorJavadoc - Prepares the Dokka Module Descriptor JSON
+      |prepareDokkatooModuleDescriptorJekyll - Prepares the Dokka Module Descriptor JSON
+      |prepareDokkatooParameters - Runs all Dokkatoo Create Configuration tasks
+      |prepareDokkatooParametersGfm - Creates Dokka Configuration for executing the Dokka Generator for the gfm publication
+      |prepareDokkatooParametersHtml - Creates Dokka Configuration for executing the Dokka Generator for the html publication
+      |prepareDokkatooParametersJavadoc - Creates Dokka Configuration for executing the Dokka Generator for the javadoc publication
+      |prepareDokkatooParametersJekyll - Creates Dokka Configuration for executing the Dokka Generator for the jekyll publication
       |
     """.trimMargin()
   }
@@ -57,18 +65,69 @@ class DokkatooPluginFunctionalTest {
 
       build.output.invariantNewlines() shouldContain /* language=text */ """
         |--------------------------------------------------
-        |Variant dokkatooConfigurationElements$formatCapitalized
+        |Variant dokkatooParametersElements$formatCapitalized
         |--------------------------------------------------
-        |Provide Dokka Generator Configuration files for $format to other subprojects
+        |Provide Dokka Parameters for $format to other subprojects
         |
         |Capabilities
         |    - :test:unspecified (default capability)
         |Attributes
         |    - dev.adamko.dokkatoo.base     = dokkatoo
-        |    - dev.adamko.dokkatoo.category = configuration
+        |    - dev.adamko.dokkatoo.category = generator-parameters
         |    - dev.adamko.dokkatoo.format   = $format
         |Artifacts
-        |    - build/dokka-config/$format/dokka_configuration.json (artifactType = json)
+        |    - build/dokka-config/$format/dokka_parameters.json (artifactType = json)
+      """.trimMargin().replace('/', File.separatorChar)
+
+      build.output.invariantNewlines() shouldContain /* language=text */ """
+        |--------------------------------------------------
+        |Variant dokkatooPluginElements$formatCapitalized
+        |--------------------------------------------------
+        |Provide the Dokka Plugins classpath for $format to other subprojects
+        |
+        |Capabilities
+        |    - :test:unspecified (default capability)
+        |Attributes
+        |    - dev.adamko.dokkatoo.base       = dokkatoo
+        |    - dev.adamko.dokkatoo.category   = plugins-classpath
+        |    - dev.adamko.dokkatoo.format     = $format
+        |    - org.gradle.category            = library
+        |    - org.gradle.dependency.bundling = external
+        |    - org.gradle.jvm.environment     = standard-jvm
+        |    - org.gradle.libraryelements     = jar
+        |    - org.gradle.usage               = java-runtime
+      """.trimMargin().replace('/', File.separatorChar)
+
+      build.output.invariantNewlines() shouldContain /* language=text */ """
+        |--------------------------------------------------
+        |Variant dokkatooModuleDescriptorsElements$formatCapitalized
+        |--------------------------------------------------
+        |Provide Dokka Module Descriptors for $format to other subprojects
+        |
+        |Capabilities
+        |    - :test:unspecified (default capability)
+        |Attributes
+        |    - dev.adamko.dokkatoo.base     = dokkatoo
+        |    - dev.adamko.dokkatoo.category = module-descriptor
+        |    - dev.adamko.dokkatoo.format   = $format
+        |Artifacts
+        |    - build/dokka-config/${format}/module_descriptor.json (artifactType = json)
+      """.trimMargin().replace('/', File.separatorChar)
+
+      build.output.invariantNewlines() shouldContain /* language=text */ """
+        |--------------------------------------------------
+        |Variant dokkatooModuleSourceElements$formatCapitalized
+        |--------------------------------------------------
+        |Provide Dokka Module Source Output for $format to other subprojects
+        |
+        |Capabilities
+        |    - :test:unspecified (default capability)
+        |Attributes
+        |    - dev.adamko.dokkatoo.base     = dokkatoo
+        |    - dev.adamko.dokkatoo.category = module-source
+        |    - dev.adamko.dokkatoo.format   = $format
+        |Artifacts
+        |    - build/dokka-module/$format
         |
       """.trimMargin().replace('/', File.separatorChar)
     }
@@ -108,13 +167,13 @@ class DokkatooPluginFunctionalTest {
 
       build.output.invariantNewlines() shouldContain /* language=text */ """
         |--------------------------------------------------
-        |Configuration dokkatooConfiguration$formatCapitalized
+        |Configuration dokkatooParameters$formatCapitalized
         |--------------------------------------------------
-        |Fetch Dokka Generator Configuration files for $format from other subprojects
+        |Fetch Dokka Parameters for $format from other subprojects
         |
         |Attributes
         |    - dev.adamko.dokkatoo.base     = dokkatoo
-        |    - dev.adamko.dokkatoo.category = configuration
+        |    - dev.adamko.dokkatoo.category = generator-parameters
         |    - dev.adamko.dokkatoo.format   = $format
         |Extended Configurations
         |    - dokkatoo

--- a/modules/dokkatoo-base-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-base-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -68,16 +68,18 @@ class MultiModuleFunctionalTest {
       |//}
     """.trimMargin()
 
-//        createKotlinFile(
-//            "src/main/kotlin/Dummy.kt", """
-//                package com.project.dummy
-//
-//                /** Dummy class - this is only here to trigger Dokka */
-//                class Dummy {
-//                    val nothing: String = ""
-//                }
-//            """.trimIndent()
-//        )
+    //createKotlinFile(
+    //  "src/main/kotlin/Dummy.kt",
+    //    """
+    //      |package com.project.dummy
+    //      |
+    //      |/** Dummy class - this is only here to trigger Dokka */
+    //      |class Dummy {
+    //      |    val nothing: String = ""
+    //      |}
+    //      |
+    //    """.trimMargin()
+    //)
 
     createKtsFile(
       "subproject-hello/build.gradle.kts",
@@ -206,7 +208,7 @@ class MultiModuleFunctionalTest {
     project.projectDir.resolve("subproject/build/dokka/html/com/project/hello/Hello.html")
       .shouldBeAFile()
     project.projectDir.resolve("subproject/build/dokka/html/index.html").shouldBeAFile()
-    project.projectDir.resolve("subproject/build/dokka/html/dokka_configuration.json")
+    project.projectDir.resolve("subproject/build/dokka/html/dokka_parameters.json")
       .shouldBeAFile()
     project.projectDir.resolve("subproject/build/dokka/html/element-list").shouldBeAFile()
     project.projectDir.resolve("subproject/build/dokka/html/element-list").toFile().readText()
@@ -234,7 +236,7 @@ class MultiModuleFunctionalTest {
 
 //        project.projectDir.resolve("subproject/build/dokka-output/com/project/hello/Hello.html").shouldBeAFile()
 //        project.projectDir.resolve("subproject/build/dokka-output/index.html").shouldBeAFile()
-//        project.projectDir.resolve("subproject/build/dokka-config/dokka_configuration.json").shouldBeAFile()
+//        project.projectDir.resolve("subproject/build/dokka-config/dokka_parameters.json").shouldBeAFile()
 //        project.projectDir.resolve("subproject/build/dokka-output/element-list").shouldBeAFile()
 //        project.projectDir.resolve("subproject/build/dokka-output/element-list").toFile().readText().shouldContain(
 //            """
@@ -246,7 +248,7 @@ class MultiModuleFunctionalTest {
 //        )
 
     val dokkaConfigurationFile =
-      project.projectDir.resolve("build/dokka-config/html/dokka_configuration.json")
+      project.projectDir.resolve("build/dokka-config/html/dokka_parameters.json")
     dokkaConfigurationFile.shouldExist()
     dokkaConfigurationFile.shouldBeAFile()
     @OptIn(ExperimentalSerializationApi::class)
@@ -264,7 +266,7 @@ class MultiModuleFunctionalTest {
       )
 
       pluginClasspathJars.shouldContainExactlyInAnyOrder(
-        "markdown-jvm-0.3.1.jar",
+//        "markdown-jvm-0.3.1.jar",
         "kotlin-analysis-intellij-1.7.20.jar",
         "dokka-base-1.7.20.jar",
         "templating-plugin-1.7.20.jar",

--- a/modules/dokkatoo-base-plugin/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-base-plugin/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -53,7 +53,7 @@ class BasicProjectIntegrationTest {
 
     val actualDokkaConfJson = basicProject
       .projectDir
-      .resolve("build/dokka-config/html/dokka_configuration.json")
+      .resolve("build/dokka-config/html/dokka_parameters.json")
       .toFile()
       .readText()
 


### PR DESCRIPTION
- send/receive Dokka Module JSON conf and Dokka Module src-dir across subprojects via specific Gradle Configurations
- Rename some classes/props to better match 'Dokka Parameters naming'
- move jetbrains-markdown to be Dokka Generator dependency (since it's not a Dokka plugin)