### PR TITLE
Refactor builder classes

### DIFF
--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -142,10 +142,6 @@ private fun initDokkaProject(
         """../template.root.gradle.kts""",
         """./template.root.gradle.kts""",
       )
-      .replace(
-        """kotlin("jvm")""",
-        """kotlin("jvm") version "1.7.22"""",
-      )
 
     // update relative paths to the template files - they're now in the same directory
     settingsGradleKts = settingsGradleKts
@@ -154,21 +150,9 @@ private fun initDokkaProject(
         """./template.settings.gradle.kts""",
       )
 
-    var templateGradleBuild: String by projectFile("template.root.gradle.kts")
-    templateGradleBuild = ""
-
     var templateGradleSettings: String by projectFile("template.settings.gradle.kts")
     templateGradleSettings = templateGradleSettings
       .replace("for-integration-tests-SNAPSHOT", "1.7.20")
-//      .replace(
-//        """maven("https://cache-redirector.jetbrains.com/jcenter.bintray.com")""",
-//        """//maven("https://cache-redirector.jetbrains.com/jcenter.bintray.com")""",
-//      )
-//      .replace(
-//        """maven("http""",
-//        """//maven("http""",
-//      )
-    templateGradleSettings = ""
   }
 }
 

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -1,8 +1,16 @@
 package dev.adamko.dokkatoo.tests.integration
 
-import dev.adamko.dokkatoo.utils.*
+import dev.adamko.dokkatoo.utils.GradleProjectTest
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.integrationTestProjectsDir
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
+import dev.adamko.dokkatoo.utils.buildGradleKts
+import dev.adamko.dokkatoo.utils.copyIntegrationTestProject
+import dev.adamko.dokkatoo.utils.projectFile
+import dev.adamko.dokkatoo.utils.settingsGradleKts
+import dev.adamko.dokkatoo.utils.shouldContainAll
+import dev.adamko.dokkatoo.utils.sideBySide
+import dev.adamko.dokkatoo.utils.toTreeString
+import dev.adamko.dokkatoo.utils.withEnvironment
 import io.kotest.assertions.withClue
 import io.kotest.matchers.file.shouldHaveSameStructureAndContentAs
 import io.kotest.matchers.file.shouldHaveSameStructureAs
@@ -28,7 +36,8 @@ class BasicProjectIntegrationTest {
     val tempDir = projectTestTempDir.resolve("it/it-basic").toFile()
 
     val dokkaDir = tempDir.resolve("dokka")
-    basicProjectSrcDir.toFile().copyRecursively(dokkaDir, overwrite = true) { _, _ -> OnErrorAction.SKIP }
+    basicProjectSrcDir.toFile()
+      .copyRecursively(dokkaDir, overwrite = true) { _, _ -> OnErrorAction.SKIP }
 
     val dokkaProject = initDokkaProject(dokkaDir)
 
@@ -37,7 +46,7 @@ class BasicProjectIntegrationTest {
         "clean",
         "dokkaHtml",
         "--stacktrace",
-        "--info",
+        "--debug",
       )
       .forwardOutput()
       .withEnvironment(
@@ -128,6 +137,15 @@ private fun initDokkaProject(
         """file("../customResources/""",
         """file("./customResources/""",
       )
+      // update relative paths to the template files - they're now in the same directory
+      .replace(
+        """../template.root.gradle.kts""",
+        """./template.root.gradle.kts""",
+      )
+      .replace(
+        """kotlin("jvm")""",
+        """kotlin("jvm") version "1.7.22"""",
+      )
 
     // update relative paths to the template files - they're now in the same directory
     settingsGradleKts = settingsGradleKts
@@ -135,14 +153,22 @@ private fun initDokkaProject(
         """../template.settings.gradle.kts""",
         """./template.settings.gradle.kts""",
       )
-    buildGradleKts = buildGradleKts
-      .replace(
-        """../template.root.gradle.kts""",
-        """./template.root.gradle.kts""",
-      )
+
+    var templateGradleBuild: String by projectFile("template.root.gradle.kts")
+    templateGradleBuild = ""
+
     var templateGradleSettings: String by projectFile("template.settings.gradle.kts")
     templateGradleSettings = templateGradleSettings
       .replace("for-integration-tests-SNAPSHOT", "1.7.20")
+//      .replace(
+//        """maven("https://cache-redirector.jetbrains.com/jcenter.bintray.com")""",
+//        """//maven("https://cache-redirector.jetbrains.com/jcenter.bintray.com")""",
+//      )
+//      .replace(
+//        """maven("http""",
+//        """//maven("http""",
+//      )
+    templateGradleSettings = ""
   }
 }
 

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -46,7 +46,7 @@ class BasicProjectIntegrationTest {
         "clean",
         "dokkaHtml",
         "--stacktrace",
-        "--debug",
+        "--info",
       )
       .forwardOutput()
       .withEnvironment(

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -316,7 +316,7 @@ abstract class DokkatooBasePlugin @Inject constructor(
       suppressGeneratedFiles.convention(true)
 
       sourceLinks.configureEach {
-        localDirectory.convention(layout.projectDirectory.asFile)
+        localDirectory.convention(layout.projectDirectory)
         remoteLineSuffix.convention("#L")
       }
 
@@ -325,8 +325,6 @@ abstract class DokkatooBasePlugin @Inject constructor(
         suppress.convention(false)
         skipDeprecated.convention(false)
         reportUndocumented.convention(false)
-        @Suppress("DEPRECATION")
-        includeNonPublic.convention(false)
       }
 
       externalDocumentationLinks {

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -7,7 +7,7 @@ import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companio
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKA_FORMAT_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooFormatGradleConfigurations
 import dev.adamko.dokkatoo.dokka.DokkaPublication
-import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationGradleBuilder
+import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec
 import dev.adamko.dokkatoo.formats.*
 import dev.adamko.dokkatoo.internal.*
 import dev.adamko.dokkatoo.tasks.DokkatooGenerateTask
@@ -204,7 +204,7 @@ abstract class DokkatooBasePlugin @Inject constructor(
           @Suppress("DEPRECATION")
           pluginsMapConfiguration.map { pluginConfig ->
             pluginConfig.map { (pluginId, pluginConfiguration) ->
-              objects.newInstance<DokkaPluginConfigurationGradleBuilder>(pluginId).apply {
+              objects.newInstance<DokkaPluginConfigurationSpec>(pluginId).apply {
                 values.set(pluginConfiguration)
               }
             }

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
@@ -1,7 +1,7 @@
 package dev.adamko.dokkatoo
 
 import dev.adamko.dokkatoo.dokka.DokkaPublication
-import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetGradleBuilder
+import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.plugins.ExtensionAware
@@ -71,7 +71,7 @@ abstract class DokkatooExtension : ExtensionAware {
    *
    * Dokka will merge Dokka Source Sets from other subprojects if...
    */
-  abstract val dokkatooSourceSets: NamedDomainObjectContainer<DokkaSourceSetGradleBuilder>
+  abstract val dokkatooSourceSets: NamedDomainObjectContainer<DokkaSourceSetSpec>
 
   interface Versions {
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
@@ -12,7 +12,7 @@ import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.GENERATE_MODULE
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.GENERATE_PUBLICATION
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.PREPARE_MODULE_DESCRIPTOR
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.PREPARE_PARAMETERS
-import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationGradleBuilder
+import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec
 import java.io.Serializable
 import javax.inject.Inject
 import org.gradle.api.Named
@@ -85,7 +85,7 @@ abstract class DokkaPublication @Inject constructor(
 //    abstract val pluginsClasspath: ConfigurableFileCollection
 
   @get:Nested
-  abstract val pluginsConfiguration: NamedDomainObjectContainer<DokkaPluginConfigurationGradleBuilder>
+  abstract val pluginsConfiguration: NamedDomainObjectContainer<DokkaPluginConfigurationSpec>
 
 //    /** Dokka Configuration files from other subprojects that will be merged into this Dokka Configuration */
 //    @get:InputFiles

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpec.kt
@@ -31,7 +31,7 @@ import org.gradle.api.tasks.Internal
  * }
  * ```
  */
-abstract class DokkaExternalDocumentationLinkGradleBuilder @Inject constructor(
+abstract class DokkaExternalDocumentationLinkSpec @Inject constructor(
   private val name: String
 ) : Serializable, Named {
 
@@ -97,9 +97,9 @@ abstract class DokkaExternalDocumentationLinkGradleBuilder @Inject constructor(
   /**
    * If enabled this link will be passed to the Dokka Generator.
    *
-   * @see dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetGradleBuilder.noStdlibLink
-   * @see dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetGradleBuilder.noJdkLink
-   * @see dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetGradleBuilder.noAndroidSdkLink
+   * @see dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec.noStdlibLink
+   * @see dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec.noJdkLink
+   * @see dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec.noAndroidSdkLink
    */
   @get:Input
   abstract val enabled: Property<Boolean>

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaModuleDescriptionSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaModuleDescriptionSpec.kt
@@ -9,7 +9,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.jetbrains.dokka.DokkaConfigurationBuilder
 
-abstract class DokkaModuleDescriptionGradleBuilder @Inject constructor(
+abstract class DokkaModuleDescriptionSpec @Inject constructor(
   @get:Input
   val moduleName: String,
 ) : DokkaConfigurationBuilder<DokkaParametersKxs.DokkaModuleDescriptionKxs>, Named {

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
@@ -27,7 +27,7 @@ import org.jetbrains.dokka.DokkaConfigurationBuilder
  * }
  * ```
  */
-abstract class DokkaPackageOptionsGradleBuilder :
+abstract class DokkaPackageOptionsSpec :
   DokkaConfigurationBuilder<DokkaParametersKxs.PackageOptionsKxs>,
   Serializable {
 
@@ -53,7 +53,7 @@ abstract class DokkaPackageOptionsGradleBuilder :
    * This can be used if you want to document protected/internal/private declarations within a
    * specific package, as well as if you want to exclude public declarations and only document internal API.
    *
-   * Can be configured for a whole source set, see [DokkaSourceSetGradleBuilder.documentedVisibilities].
+   * Can be configured for a whole source set, see [DokkaSourceSetSpec.documentedVisibilities].
    *
    * Default is [DokkaConfiguration.Visibility.PUBLIC].
    */
@@ -63,7 +63,7 @@ abstract class DokkaPackageOptionsGradleBuilder :
   /**
    * Whether to document declarations annotated with [Deprecated].
    *
-   * Can be overridden on source set level by setting [DokkaSourceSetGradleBuilder.skipDeprecated].
+   * Can be overridden on source set level by setting [DokkaSourceSetSpec.skipDeprecated].
    *
    * Default is `false`.
    */
@@ -76,7 +76,7 @@ abstract class DokkaPackageOptionsGradleBuilder :
    *
    * This setting works well with [AbstractDokkaTask.failOnWarning].
    *
-   * Can be overridden on source set level by setting [DokkaSourceSetGradleBuilder.reportUndocumented].
+   * Can be overridden on source set level by setting [DokkaSourceSetSpec.reportUndocumented].
    *
    * Default is `false`.
    */

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
@@ -83,13 +83,6 @@ abstract class DokkaPackageOptionsSpec :
   @get:Input
   abstract val reportUndocumented: Property<Boolean>
 
-  /**
-   * Deprecated. Use [documentedVisibilities] instead.
-   */
-  @get:Input
-  @Deprecated("Use documentedVisibilities instead")
-  abstract val includeNonPublic: Property<Boolean>
-
 
   override fun build() = DokkaParametersKxs.PackageOptionsKxs(
     matchingRegex = matchingRegex.get(),

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPluginConfigurationSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPluginConfigurationSpec.kt
@@ -12,7 +12,7 @@ import org.jetbrains.dokka.DokkaConfigurationBuilder
 /**
  * @param[pluginFqn] Fully qualified classname of the Dokka Plugin
  */
-abstract class DokkaPluginConfigurationGradleBuilder @Inject constructor(
+abstract class DokkaPluginConfigurationSpec @Inject constructor(
   @get:Internal
   val pluginFqn: String
 ) :

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPluginConfigurationSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPluginConfigurationSpec.kt
@@ -13,7 +13,7 @@ import org.jetbrains.dokka.DokkaConfigurationBuilder
  * @param[pluginFqn] Fully qualified classname of the Dokka Plugin
  */
 abstract class DokkaPluginConfigurationSpec @Inject constructor(
-  @get:Internal
+  @get:Input
   val pluginFqn: String
 ) :
   DokkaConfigurationBuilder<DokkaParametersKxs.PluginConfigurationKxs>,
@@ -32,6 +32,6 @@ abstract class DokkaPluginConfigurationSpec @Inject constructor(
     values = values.get(),
   )
 
-  @Input
+  @Internal
   override fun getName(): String = pluginFqn
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceLinkSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceLinkSpec.kt
@@ -25,7 +25,7 @@ import org.jetbrains.dokka.DokkaConfigurationBuilder
  * }
  * ```
  */
-abstract class DokkaSourceLinkGradleBuilder :
+abstract class DokkaSourceLinkSpec :
   DokkaConfigurationBuilder<DokkaParametersKxs.SourceLinkDefinitionKxs>,
   Serializable {
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceLinkSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceLinkSpec.kt
@@ -1,8 +1,8 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
-import java.io.File
 import java.io.Serializable
 import java.net.URL
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
@@ -43,16 +43,15 @@ abstract class DokkaSourceLinkSpec :
    * ```
    */
   @get:Internal // changing contents of the directory should not invalidate the task
-  abstract val localDirectory: Property<File>
+  abstract val localDirectory: DirectoryProperty
 
   /**
    * The relative path to [localDirectory] from the project directory. Declared as an input to invalidate the task if that path changes.
    * Should not be used anywhere directly.
    */
-//    @Suppress("unused")
   @get:Input
   protected val localDirectoryPath: Provider<String>
-    get() = localDirectory.map { it.path }
+    get() = localDirectory.map { it.asFile.invariantSeparatorsPath }
 
   /**
    * URL of source code hosting service that can be accessed by documentation readers,
@@ -103,7 +102,7 @@ abstract class DokkaSourceLinkSpec :
 
   override fun build(): DokkaParametersKxs.SourceLinkDefinitionKxs {
     return DokkaParametersKxs.SourceLinkDefinitionKxs(
-      localDirectory = localDirectory.get().canonicalPath,
+      localDirectory = localDirectory.get().asFile.invariantSeparatorsPath,
       remoteUrl = remoteUrl.get(),
       remoteLineSuffix = remoteLineSuffix.orNull,
     )

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetIDSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetIDSpec.kt
@@ -6,7 +6,7 @@ import org.gradle.api.tasks.Internal
 import org.jetbrains.dokka.DokkaConfigurationBuilder
 import org.jetbrains.dokka.DokkaSourceSetID
 
-abstract class DokkaSourceSetIDGradleBuilder(
+abstract class DokkaSourceSetIDSpec(
   /**
    * Unique identifier of the scope that this source set is placed in.
    * Each scope provide only unique source set names.

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
@@ -36,7 +36,7 @@ import org.jetbrains.dokka.*
  * }
  * ```
  */
-abstract class DokkaSourceSetGradleBuilder(
+abstract class DokkaSourceSetSpec(
   private val name: String
 ) :
   DokkaConfigurationBuilder<DokkaParametersKxs.DokkaSourceSetKxs>,
@@ -122,7 +122,7 @@ abstract class DokkaSourceSetGradleBuilder(
    * This can be used if you want to document protected/internal/private declarations,
    * as well as if you want to exclude public declarations and only document internal API.
    *
-   * Can be configured on per-package basis, see [DokkaPackageOptionsGradleBuilder.documentedVisibilities].
+   * Can be configured on per-package basis, see [DokkaPackageOptionsSpec.documentedVisibilities].
    *
    * Default is [DokkaConfiguration.Visibility.PUBLIC].
    */
@@ -144,7 +144,7 @@ abstract class DokkaSourceSetGradleBuilder(
    * By default, the values are deduced from information provided by the Kotlin Gradle plugin.
    */
   @get:Nested
-  abstract val dependentSourceSets: NamedDomainObjectContainer<DokkaSourceSetIDGradleBuilder>
+  abstract val dependentSourceSets: NamedDomainObjectContainer<DokkaSourceSetIDSpec>
 
   /**
    * Classpath for analysis and interactive samples.
@@ -185,7 +185,7 @@ abstract class DokkaSourceSetGradleBuilder(
    *
    * This setting works well with [AbstractDokkaTask.failOnWarning].
    *
-   * Can be overridden for a specific package by setting [DokkaPackageOptionsGradleBuilder.reportUndocumented].
+   * Can be overridden for a specific package by setting [DokkaPackageOptionsSpec.reportUndocumented].
    *
    * Default is `false`.
    */
@@ -194,22 +194,22 @@ abstract class DokkaSourceSetGradleBuilder(
 
   /**
    * Specifies the location of the project source code on the Web. If provided, Dokka generates
-   * "source" links for each declaration. See [DokkaSourceLinkGradleBuilder] for more details.
+   * "source" links for each declaration. See [DokkaSourceLinkSpec] for more details.
    *
    * Prefer using [sourceLink] action/closure for adding source links.
    *
    * @see sourceLink
    */
   @get:Nested
-  abstract val sourceLinks: DomainObjectSet<DokkaSourceLinkGradleBuilder>
+  abstract val sourceLinks: DomainObjectSet<DokkaSourceLinkSpec>
 
   /**
    * Allows to customize documentation generation options on a per-package basis.
    *
-   * @see DokkaPackageOptionsGradleBuilder for details
+   * @see DokkaPackageOptionsSpec for details
    */
   @get:Nested
-  abstract val perPackageOptions: DomainObjectSet<DokkaPackageOptionsGradleBuilder>
+  abstract val perPackageOptions: DomainObjectSet<DokkaPackageOptionsSpec>
 
   /**
    * Allows linking to Dokka/Javadoc documentation of the project's dependencies.
@@ -217,7 +217,7 @@ abstract class DokkaSourceSetGradleBuilder(
    * Prefer using [externalDocumentationLink] action/closure for adding links.
    */
   @get:Nested
-  abstract val externalDocumentationLinks: NamedDomainObjectContainer<DokkaExternalDocumentationLinkGradleBuilder>
+  abstract val externalDocumentationLinks: NamedDomainObjectContainer<DokkaExternalDocumentationLinkSpec>
 
   /**
    * Platform to be used for setting up code analysis and samples.
@@ -242,7 +242,7 @@ abstract class DokkaSourceSetGradleBuilder(
   /**
    * Whether to document declarations annotated with [Deprecated].
    *
-   * Can be overridden on package level by setting [DokkaPackageOptionsGradleBuilder.skipDeprecated].
+   * Can be overridden on package level by setting [DokkaPackageOptionsSpec.skipDeprecated].
    *
    * Default is `false`.
    */
@@ -336,7 +336,7 @@ abstract class DokkaSourceSetGradleBuilder(
   @get:Input
   abstract val jdkVersion: Property<Int>
 
-  fun DokkaSourceSetID(sourceSetName: String): DokkaSourceSetIDGradleBuilder {
+  fun DokkaSourceSetID(sourceSetName: String): DokkaSourceSetIDSpec {
     return dependentSourceSets.create("TODO figure out scope ID") {
       this.sourceSetName = sourceSetName
     }
@@ -377,11 +377,11 @@ abstract class DokkaSourceSetGradleBuilder(
   /**
    * Action for configuring source links, appending to [sourceLinks].
    *
-   * @see [DokkaSourceLinkGradleBuilder] for details.
+   * @see [DokkaSourceLinkSpec] for details.
    */
-  fun sourceLink(action: Action<in DokkaSourceLinkGradleBuilder>) {
+  fun sourceLink(action: Action<in DokkaSourceLinkSpec>) {
     sourceLinks.add(
-      objects.newInstance(DokkaSourceLinkGradleBuilder::class).also {
+      objects.newInstance(DokkaSourceLinkSpec::class).also {
         action.execute(it)
       }
     )
@@ -401,11 +401,11 @@ abstract class DokkaSourceSetGradleBuilder(
   /**
    * Action for configuring package options, appending to [perPackageOptions].
    *
-   * @see [DokkaPackageOptionsGradleBuilder] for details.
+   * @see [DokkaPackageOptionsSpec] for details.
    */
-  fun perPackageOption(action: Action<in DokkaPackageOptionsGradleBuilder>) {
+  fun perPackageOption(action: Action<in DokkaPackageOptionsSpec>) {
     perPackageOptions.add(
-      objects.newInstance(DokkaPackageOptionsGradleBuilder::class).also {
+      objects.newInstance(DokkaPackageOptionsSpec::class).also {
         action.execute(it)
       }
     )
@@ -425,11 +425,11 @@ abstract class DokkaSourceSetGradleBuilder(
   /**
    * Action for configuring external documentation links, appending to [externalDocumentationLinks].
    *
-   * See [DokkaExternalDocumentationLinkGradleBuilder] for details.
+   * See [DokkaExternalDocumentationLinkSpec] for details.
    */
-  fun externalDocumentationLink(action: Action<in DokkaExternalDocumentationLinkGradleBuilder>) {
+  fun externalDocumentationLink(action: Action<in DokkaExternalDocumentationLinkSpec>) {
     externalDocumentationLinks.add(
-      objects.newInstance(DokkaExternalDocumentationLinkGradleBuilder::class).also {
+      objects.newInstance(DokkaExternalDocumentationLinkSpec::class).also {
         action.execute(it)
       }
     )
@@ -443,7 +443,7 @@ abstract class DokkaSourceSetGradleBuilder(
   /** Convenient override to **append** external documentation links to [externalDocumentationLinks]. */
   fun externalDocumentationLink(url: URL, packageListUrl: URL? = null) {
     externalDocumentationLinks.add(
-      objects.newInstance(DokkaExternalDocumentationLinkGradleBuilder::class).also {
+      objects.newInstance(DokkaExternalDocumentationLinkSpec::class).also {
         it.url.set(url)
         if (packageListUrl != null) {
           it.packageListUrl.set(packageListUrl)
@@ -454,7 +454,7 @@ abstract class DokkaSourceSetGradleBuilder(
 
   override fun build(): DokkaParametersKxs.DokkaSourceSetKxs {
     val externalDocumentationLinks = externalDocumentationLinks
-      .mapNotNull(DokkaExternalDocumentationLinkGradleBuilder::build)
+      .mapNotNull(DokkaExternalDocumentationLinkSpec::build)
       .toSet()
 
     return DokkaParametersKxs.DokkaSourceSetKxs(
@@ -462,15 +462,15 @@ abstract class DokkaSourceSetGradleBuilder(
       displayName = displayName.get(),
       classpath = classpath.files.toList(),
       sourceRoots = sourceRoots.files,
-      dependentSourceSets = dependentSourceSets.map(DokkaSourceSetIDGradleBuilder::build).toSet(),
+      dependentSourceSets = dependentSourceSets.map(DokkaSourceSetIDSpec::build).toSet(),
       samples = samples.files,
       includes = includes.files,
       reportUndocumented = reportUndocumented.get(),
       skipEmptyPackages = skipEmptyPackages.get(),
       skipDeprecated = skipDeprecated.get(),
       jdkVersion = jdkVersion.get(),
-      sourceLinks = sourceLinks.map(DokkaSourceLinkGradleBuilder::build).toSet(),
-      perPackageOptions = perPackageOptions.map(DokkaPackageOptionsGradleBuilder::build),
+      sourceLinks = sourceLinks.map(DokkaSourceLinkSpec::build).toSet(),
+      perPackageOptions = perPackageOptions.map(DokkaPackageOptionsSpec::build),
       externalDocumentationLinks = externalDocumentationLinks,
       languageVersion = languageVersion.orNull,
       apiVersion = apiVersion.orNull,

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
@@ -1,6 +1,5 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
-import java.io.File
 import java.io.Serializable
 import java.net.URL
 import javax.inject.Inject
@@ -161,8 +160,6 @@ abstract class DokkaSourceSetSpec(
   /**
    * Source code roots to be analyzed and documented.
    * Accepts directories and individual `.kt` / `.java` files.
-   *
-   * Prefer using [sourceRoot] function to append source roots to this list.
    *
    * By default, source roots are deduced from information provided by the Kotlin Gradle plugin.
    */
@@ -335,44 +332,6 @@ abstract class DokkaSourceSetSpec(
    */
   @get:Input
   abstract val jdkVersion: Property<Int>
-
-  fun DokkaSourceSetID(sourceSetName: String): DokkaSourceSetIDSpec {
-    return dependentSourceSets.create("TODO figure out scope ID") {
-      this.sourceSetName = sourceSetName
-    }
-  }
-
-  /** Convenient override to **append** source sets to [dependentSourceSets] */
-  fun dependsOn(sourceSet: SourceSet): Unit = dependsOn(sourceSet.name)
-
-//    /** Convenient override to **append** source sets to [dependentSourceSets] */
-//    fun dependsOn(sourceSet: DokkaSourceSetGradleBuilder): Unit {
-//        dependentSourceSets.add(sourceSet.sourceSetID.get())
-//    }
-
-  /** Convenient override to **append** source sets to [dependentSourceSets] */
-  fun dependsOn(sourceSet: DokkaConfiguration.DokkaSourceSet): Unit =
-    dependsOn(sourceSet.sourceSetID)
-
-  /** Convenient override to **append** source sets to [dependentSourceSets] */
-  fun dependsOn(sourceSetName: String): Unit = dependsOn(sourceSetName)
-
-  /** Convenient override to **append** source sets to [dependentSourceSets] */
-  fun dependsOn(sourceSetID: DokkaSourceSetID) {
-    dependentSourceSets.create(sourceSetID.scopeId) {
-      sourceSetName = sourceSetID.sourceSetName
-    }
-  }
-
-  /** Convenient override to **append** source roots to [sourceRoots] */
-  fun sourceRoot(file: File) {
-    sourceRoots.from(file)
-  }
-
-  /** Convenient override to **append** source roots to [sourceRoots] */
-  fun sourceRoot(path: String) {
-    sourceRoots.from(path)
-  }
 
   /**
    * Action for configuring source links, appending to [sourceLinks].

--- a/modules/dokkatoo-plugin/src/main/kotlin/migrations/dokkaGradle.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/migrations/dokkaGradle.kt
@@ -2,7 +2,7 @@
 
 package org.jetbrains.dokka.gradle
 
-import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetGradleBuilder
+import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
 // temp disabled - maybe move migrations to a separate subproject?
@@ -18,6 +18,6 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
  * Extension allowing configuration of Dokka source sets via Kotlin Gradle plugin source sets.
  */
 @Deprecated("dokkatoo...") // TODO what's the replacement...?
-fun DokkaSourceSetGradleBuilder.kotlinSourceSet(kotlinSourceSet: KotlinSourceSet) {
+fun DokkaSourceSetSpec.kotlinSourceSet(kotlinSourceSet: KotlinSourceSet) {
   todoSourceSetName.set(kotlinSourceSet.name)
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooPrepareParametersTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooPrepareParametersTask.kt
@@ -2,8 +2,8 @@ package dev.adamko.dokkatoo.tasks
 
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.jsonMapper
 import dev.adamko.dokkatoo.dokka.parameters.DokkaParametersKxs
-import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationGradleBuilder
-import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetGradleBuilder
+import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec
+import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
 import java.io.IOException
 import javax.inject.Inject
 import kotlinx.serialization.encodeToString
@@ -54,7 +54,7 @@ abstract class DokkatooPrepareParametersTask @Inject constructor(
   abstract val delayTemplateSubstitution: Property<Boolean>
 
   @get:Nested
-  abstract val dokkaSourceSets: NamedDomainObjectContainer<DokkaSourceSetGradleBuilder>
+  abstract val dokkaSourceSets: NamedDomainObjectContainer<DokkaSourceSetSpec>
 
   @get:Input
   abstract val failOnWarning: Property<Boolean>
@@ -95,7 +95,7 @@ abstract class DokkatooPrepareParametersTask @Inject constructor(
   abstract val pluginsClasspath: ConfigurableFileCollection
 
   @get:Nested
-  abstract val pluginsConfiguration: DomainObjectSet<DokkaPluginConfigurationGradleBuilder>
+  abstract val pluginsConfiguration: DomainObjectSet<DokkaPluginConfigurationSpec>
 
   @get:Input
   abstract val suppressObviousFunctions: Property<Boolean>
@@ -135,12 +135,12 @@ abstract class DokkatooPrepareParametersTask @Inject constructor(
       val suppressed = it.suppress.get()
       logger.info("Dokka source set ${it.sourceSetID.get()} ${if (suppressed) "is" else "isn't"} suppressed")
       suppressed
-    }.map(DokkaSourceSetGradleBuilder::build)
+    }.map(DokkaSourceSetSpec::build)
 
     val pluginsClasspath = pluginsClasspath.files.toList()
 
     val pluginsConfiguration =
-      pluginsConfiguration.map(DokkaPluginConfigurationGradleBuilder::build)
+      pluginsConfiguration.map(DokkaPluginConfigurationSpec::build)
     val failOnWarning = failOnWarning.get()
     val delayTemplateSubstitution = delayTemplateSubstitution.get()
     val suppressObviousFunctions = suppressObviousFunctions.get()

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpecTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpecTest.kt
@@ -1,0 +1,67 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+import dev.adamko.dokkatoo.create_
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.gradle.kotlin.dsl.domainObjectContainer
+import org.gradle.testfixtures.ProjectBuilder
+
+
+class DokkaExternalDocumentationLinkSpecTest : FunSpec({
+
+  context("expect url can be set") {
+    test("using a string") {
+      val project = ProjectBuilder.builder().build()
+
+      val container = project.objects
+        .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
+
+      val actual = container.create_("test") {
+        url("https://github.com/adamko-dev/dokkatoo/")
+      }
+
+      actual.url.get().toString() shouldBe "https://github.com/adamko-dev/dokkatoo/"
+    }
+
+    test("using a string-provider") {
+      val project = ProjectBuilder.builder().build()
+
+      val container = project.objects
+        .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
+
+      val actual = container.create_("test") {
+        url(project.provider { "https://github.com/adamko-dev/dokkatoo/" })
+      }
+
+      actual.url.get().toString() shouldBe "https://github.com/adamko-dev/dokkatoo/"
+    }
+  }
+
+  context("expect packageListUrl can be set") {
+    test("using a string") {
+      val project = ProjectBuilder.builder().build()
+
+      val container = project.objects
+        .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
+
+      val actual = container.create_("test") {
+        packageListUrl("https://github.com/adamko-dev/dokkatoo/")
+      }
+
+      actual.packageListUrl.get().toString() shouldBe "https://github.com/adamko-dev/dokkatoo/"
+    }
+
+    test("using a string-provider") {
+      val project = ProjectBuilder.builder().build()
+
+      val container = project.objects
+        .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
+
+      val actual = container.create_("test") {
+        packageListUrl(project.provider { "https://github.com/adamko-dev/dokkatoo/" })
+      }
+
+      actual.packageListUrl.get().toString() shouldBe "https://github.com/adamko-dev/dokkatoo/"
+    }
+  }
+})

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpecTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpecTest.kt
@@ -1,22 +1,23 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
 import dev.adamko.dokkatoo.create_
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.net.URL
+import org.gradle.api.Project
+import org.gradle.api.internal.provider.MissingValueException
 import org.gradle.kotlin.dsl.domainObjectContainer
 import org.gradle.testfixtures.ProjectBuilder
 
 
 class DokkaExternalDocumentationLinkSpecTest : FunSpec({
+  val project = ProjectBuilder.builder().build()
 
   context("expect url can be set") {
     test("using a string") {
-      val project = ProjectBuilder.builder().build()
-
-      val container = project.objects
-        .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
-
-      val actual = container.create_("test") {
+      val actual = project.createExternalDocLinkSpec("test") {
         url("https://github.com/adamko-dev/dokkatoo/")
       }
 
@@ -24,12 +25,7 @@ class DokkaExternalDocumentationLinkSpecTest : FunSpec({
     }
 
     test("using a string-provider") {
-      val project = ProjectBuilder.builder().build()
-
-      val container = project.objects
-        .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
-
-      val actual = container.create_("test") {
+      val actual = project.createExternalDocLinkSpec("test") {
         url(project.provider { "https://github.com/adamko-dev/dokkatoo/" })
       }
 
@@ -39,12 +35,7 @@ class DokkaExternalDocumentationLinkSpecTest : FunSpec({
 
   context("expect packageListUrl can be set") {
     test("using a string") {
-      val project = ProjectBuilder.builder().build()
-
-      val container = project.objects
-        .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
-
-      val actual = container.create_("test") {
+      val actual = project.createExternalDocLinkSpec("test") {
         packageListUrl("https://github.com/adamko-dev/dokkatoo/")
       }
 
@@ -52,16 +43,46 @@ class DokkaExternalDocumentationLinkSpecTest : FunSpec({
     }
 
     test("using a string-provider") {
-      val project = ProjectBuilder.builder().build()
-
-      val container = project.objects
-        .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
-
-      val actual = container.create_("test") {
+      val actual = project.createExternalDocLinkSpec("test") {
         packageListUrl(project.provider { "https://github.com/adamko-dev/dokkatoo/" })
       }
 
       actual.packageListUrl.get().toString() shouldBe "https://github.com/adamko-dev/dokkatoo/"
     }
   }
+
+  context("when building a ExternalDocumentationLinkKxs") {
+    test("expect url is required") {
+      val actual = project.createExternalDocLinkSpec("test") {
+        url.set(null as URL?)
+        packageListUrl("https://github.com/adamko-dev/dokkatoo/")
+      }
+
+      val caughtException = shouldThrow<MissingValueException> {
+        actual.build()
+      }
+
+      caughtException.message shouldContain "Cannot query the value of property 'url' because it has no value available"
+    }
+    test("expect packageListUrl is required") {
+      val actual = project.createExternalDocLinkSpec("test") {
+        url("https://github.com/adamko-dev/dokkatoo/")
+        packageListUrl.set(null as URL?)
+      }
+
+      val caughtException = shouldThrow<MissingValueException> {
+        actual.build()
+      }
+
+      caughtException.message shouldContain "Cannot query the value of property 'packageListUrl' because it has no value available"
+    }
+  }
 })
+
+private fun Project.createExternalDocLinkSpec(
+  name: String,
+  configure: DokkaExternalDocumentationLinkSpec.() -> Unit
+): DokkaExternalDocumentationLinkSpec =
+  objects
+    .domainObjectContainer(DokkaExternalDocumentationLinkSpec::class)
+    .create_(name, configure)

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpecTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpecTest.kt
@@ -1,6 +1,7 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
 import dev.adamko.dokkatoo.create_
+import io.kotest.assertions.fail
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -8,6 +9,7 @@ import io.kotest.matchers.string.shouldContain
 import java.net.URL
 import org.gradle.api.Project
 import org.gradle.api.internal.provider.MissingValueException
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.domainObjectContainer
 import org.gradle.testfixtures.ProjectBuilder
 
@@ -75,6 +77,23 @@ class DokkaExternalDocumentationLinkSpecTest : FunSpec({
       }
 
       caughtException.message shouldContain "Cannot query the value of property 'packageListUrl' because it has no value available"
+    }
+
+    test("expect null when not enabled") {
+
+      val actual = project.createExternalDocLinkSpec("test") {
+
+        fun <T> failingProvider(propertyName: String): Provider<T> = project.provider {
+          fail("ExternalDocLink is disabled - $propertyName should not be queried")
+        }
+
+        url(failingProvider("url"))
+        packageListUrl(failingProvider("packageListUrl"))
+
+        enabled.set(false)
+      }
+
+      actual.build() shouldBe null
     }
   }
 })

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaSourceLinkSpecTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaSourceLinkSpecTest.kt
@@ -1,0 +1,145 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.io.File
+import java.net.URL
+import org.gradle.api.Project
+import org.gradle.api.internal.provider.MissingValueException
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.testfixtures.ProjectBuilder
+
+class DokkaSourceLinkSpecTest : FunSpec({
+  val project = ProjectBuilder.builder().build()
+
+  context("expect localDirectoryPath") {
+    test("is the invariantSeparatorsPath of localDirectory") {
+      val tempDir = tempdir()
+
+      val actual = project.createDokkaSourceLinkSpec {
+        localDirectory.set(tempDir)
+      }
+
+      actual.localDirectoryPath2.get() shouldBe tempDir.invariantSeparatorsPath
+    }
+  }
+
+
+  context("expect remoteUrl can be set") {
+    test("using a string") {
+      val actual = project.createDokkaSourceLinkSpec {
+        remoteUrl("https://github.com/adamko-dev/dokkatoo/")
+      }
+
+      actual.remoteUrl.get().toString() shouldBe "https://github.com/adamko-dev/dokkatoo/"
+    }
+
+    test("using a string-provider") {
+      val actual = project.createDokkaSourceLinkSpec {
+        remoteUrl(project.provider { "https://github.com/adamko-dev/dokkatoo/" })
+      }
+
+      actual.remoteUrl.get().toString() shouldBe "https://github.com/adamko-dev/dokkatoo/"
+    }
+  }
+
+
+  context("when DokkaSourceLinkSpec is built") {
+
+    test("expect built object contains all properties") {
+      val tempDir = tempdir()
+
+      val actual = project.createDokkaSourceLinkSpec {
+        localDirectory.set(tempDir)
+        remoteUrl("https://github.com/adamko-dev/dokkatoo/")
+        remoteLineSuffix.set("%L")
+      }
+
+      val actualBuilt = actual.build()
+
+      actualBuilt.should {
+        it.remoteUrl shouldBe actual.remoteUrl.get()
+        it.localDirectory shouldBe tempDir.invariantSeparatorsPath
+        it.remoteLineSuffix shouldBe "%L"
+      }
+    }
+
+    test("expect localDirectory is required") {
+      val actual = project.createDokkaSourceLinkSpec {
+        localDirectory.set(null as File?)
+        remoteUrl("https://github.com/adamko-dev/dokkatoo/")
+        remoteLineSuffix.set("%L")
+      }
+
+      val caughtException = shouldThrow<MissingValueException> {
+        actual.build()
+      }
+
+      caughtException.message shouldContain "Cannot query the value of property 'localDirectory' because it has no value available"
+    }
+
+    test("expect localDirectory is an invariantSeparatorsPath") {
+      val tempDir = tempdir()
+
+      val actual = project.createDokkaSourceLinkSpec {
+        localDirectory.set(tempDir)
+        remoteUrl("https://github.com/adamko-dev/dokkatoo/")
+        remoteLineSuffix.set(null as String?)
+      }
+
+      actual.build().should {
+        it.localDirectory shouldBe tempDir.invariantSeparatorsPath
+      }
+    }
+
+    test("expect remoteUrl is required") {
+
+      val actual = project.createDokkaSourceLinkSpec {
+        localDirectory.set(tempdir())
+        remoteUrl.set(null as URL?)
+        remoteLineSuffix.set("%L")
+      }
+
+      val caughtException = shouldThrow<MissingValueException> {
+        actual.build()
+      }
+
+      caughtException.message shouldContain "Cannot query the value of property 'remoteUrl' because it has no value available"
+    }
+
+    test("expect remoteLineSuffix is optional") {
+      val tempDir = tempdir()
+
+      val actual = project.createDokkaSourceLinkSpec {
+        localDirectory.set(tempDir)
+        remoteUrl("https://github.com/adamko-dev/dokkatoo/")
+        remoteLineSuffix.set(null as String?)
+      }
+
+      val actualBuilt = actual.build()
+
+      actualBuilt.should {
+        it.remoteUrl shouldBe actual.remoteUrl.get()
+        it.localDirectory.shouldBe(tempDir.invariantSeparatorsPath)
+        it.remoteLineSuffix.shouldBe(null)
+      }
+    }
+  }
+}) {
+  abstract class DokkaSourceLinkSpec2 : DokkaSourceLinkSpec() {
+    val localDirectoryPath2: Provider<String>
+      get() = super.localDirectoryPath
+  }
+
+  companion object {
+    private fun Project.createDokkaSourceLinkSpec(
+      configure: DokkaSourceLinkSpec.() -> Unit
+    ): DokkaSourceLinkSpec2 =
+      objects.newInstance(DokkaSourceLinkSpec2::class).apply(configure)
+  }
+}

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaSourceLinkSpecTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/DokkaSourceLinkSpecTest.kt
@@ -131,6 +131,8 @@ class DokkaSourceLinkSpecTest : FunSpec({
     }
   }
 }) {
+
+  /** Re-implement [DokkaSourceLinkSpec] to make [localDirectoryPath] accessible in tests */
   abstract class DokkaSourceLinkSpec2 : DokkaSourceLinkSpec() {
     val localDirectoryPath2: Provider<String>
       get() = super.localDirectoryPath

--- a/modules/dokkatoo-plugin/src/test/kotlin/workarounds.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/workarounds.kt
@@ -1,0 +1,79 @@
+package dev.adamko.dokkatoo
+
+import dev.adamko.dokkatoo.dokka.parameters.DokkaExternalDocumentationLinkSpec
+import dev.adamko.dokkatoo.dokka.parameters.DokkaPackageOptionsSpec
+import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceLinkSpec
+import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
+import org.gradle.api.*
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.DependencySet
+
+
+/**
+ * Workarounds because `SamWithReceiver` not working in test sources
+ * https://youtrack.jetbrains.com/issue/KTIJ-14684
+ *
+ * The `SamWithReceiver` plugin is automatically applied by the `kotlin-dsl` plugin.
+ * It converts all [org.gradle.api.Action] so the parameter is the receiver:
+ *
+ * ```
+ * // with SamWithReceiver ✅
+ * tasks.configureEach {
+ *   val task: Task = this
+ * }
+ *
+ * // without SamWithReceiver
+ * tasks.configureEach { it ->
+ *   val task: Task = it
+ * }
+ * ```
+ *
+ * This is nice because it means that the Dokka Gradle Plugin more closely matches `build.gradle.kts` files.
+ *
+ * However, [IntelliJ is bugged](https://youtrack.jetbrains.com/issue/KTIJ-14684) and doesn't
+ * acknowledge that `SamWithReceiver` has been applied in test sources. The code works and compiles,
+ * but IntelliJ shows red errors.
+ *
+ * These functions are workarounds, and should be removed ASAP.
+ */
+@Suppress("unused")
+private object Explain
+
+internal fun Project.subprojects_(configure: Project.() -> Unit) =
+  subprojects(configure)
+
+@Suppress("SpellCheckingInspection")
+internal fun Project.allprojects_(configure: Project.() -> Unit) =
+  allprojects(configure)
+
+internal fun <T> DomainObjectCollection<T>.configureEach_(configure: T.() -> Unit) =
+  configureEach(configure)
+
+internal fun <T> DomainObjectCollection<T>.all_(configure: T.() -> Unit) =
+  all(configure)
+
+internal fun Configuration.withDependencies_(action: DependencySet.() -> Unit): Configuration =
+  withDependencies(action)
+
+
+internal fun <T> NamedDomainObjectContainer<T>.create_(name: String, configure: T.() -> Unit): T =
+  create(name, configure)
+
+internal fun <T> NamedDomainObjectContainer<T>.register_(
+  name: String,
+  configure: T.() -> Unit
+): NamedDomainObjectProvider<T> =
+  register(name, configure)
+
+
+internal fun DokkaSourceSetSpec.externalDocumentationLink_(
+  action: DokkaExternalDocumentationLinkSpec.() -> Unit
+) = externalDocumentationLink(action)
+
+internal fun DokkaSourceSetSpec.sourceLink_(
+  action: DokkaSourceLinkSpec.() -> Unit
+) = sourceLink(action)
+
+internal fun DokkaSourceSetSpec.perPackageOption_(
+  action: DokkaPackageOptionsSpec.() -> Unit
+) = perPackageOption(action)


### PR DESCRIPTION
* Rename classes `*GradleBuilder` to `*Spec`, which is the naming convention of similar Gradle classes
* Add tests for some Spec classes
* remove some old helper functions from the Dokka API, because they don't help that much