### PR TITLE
log DokkaGenerator to file, not stdout

### DIFF
--- a/.github/workflows/gradle_task.yml
+++ b/.github/workflows/gradle_task.yml
@@ -57,7 +57,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build-report-${{ runner.os }}${{ github.action }}
-          path: "**/build/reports/"
+          path: |
+            **/build/reports/
+            **/*.hprof
           if-no-files-found: ignore
 
       - name: Publish Test Reports

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,3 +9,9 @@ dependencies {
 
   implementation("com.gradle.publish:plugin-publish-plugin:1.1.0")
 }
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/java-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/java-base.gradle.kts
@@ -1,0 +1,19 @@
+package buildsrc.conventions
+
+import org.gradle.api.JavaVersion
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.`java-base`
+
+plugins {
+  id("buildsrc.conventions.base")
+  `java`
+}
+
+extensions.getByType<JavaPluginExtension>().apply {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+  withSourcesJar()
+}

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-gradle-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-gradle-plugin.gradle.kts
@@ -9,3 +9,13 @@ plugins {
 tasks.validatePlugins {
   enableStricterValidation.set(true)
 }
+
+java {
+  withSourcesJar()
+}
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-gradle-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-gradle-plugin.gradle.kts
@@ -2,20 +2,11 @@ package buildsrc.conventions
 
 plugins {
   id("buildsrc.conventions.base")
+  id("buildsrc.conventions.java-base")
   id("org.gradle.kotlin.kotlin-dsl")
   id("com.gradle.plugin-publish")
 }
 
 tasks.validatePlugins {
   enableStricterValidation.set(true)
-}
-
-java {
-  withSourcesJar()
-}
-
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # memory is set quite high because the tests launch a lot of processes
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx4g -XX:MaxMetaspaceSize=2g
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx4g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError
 
 org.gradle.caching=true
 # https://github.com/gradle/gradle/issues/20416

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -210,3 +210,9 @@ tasks.withType<Test>().configureEach {
     "-XX:MaxMetaspaceSize=512m",
   )
 }
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
   `jvm-test-suite`
   `test-report-aggregation`
 
+  buildsrc.conventions.`java-base`
   buildsrc.conventions.`dokka-source-downloader`
   buildsrc.conventions.`maven-publish-test`
   buildsrc.conventions.`dokkatoo-example-projects`
@@ -209,10 +210,4 @@ tasks.withType<Test>().configureEach {
     "-Xmx1g",
     "-XX:MaxMetaspaceSize=512m",
   )
-}
-
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
 }

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
@@ -40,7 +40,8 @@ class GradleExampleTest : FunSpec({
           "dokkaHtml",
           "--stacktrace",
           "--info",
-        ).forwardOutput()
+        )
+        .forwardOutput()
         .build()
 
       dokkaBuild.output shouldContain "BUILD SUCCESSFUL"
@@ -54,7 +55,8 @@ class GradleExampleTest : FunSpec({
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--info",
-        ).forwardOutput()
+        )
+        .forwardOutput()
         .build()
 
 
@@ -95,7 +97,7 @@ class GradleExampleTest : FunSpec({
           "--info",
           "--stacktrace",
         )
-        //.forwardOutput()
+        .forwardOutput()
         .build()
 
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"
@@ -106,12 +108,14 @@ class GradleExampleTest : FunSpec({
       dokkaWorkerLog.shouldNotBeNull().shouldBeAFile()
       dokkaWorkerLog.readText() shouldContain "Generation completed successfully"
 
-      dokkatooProject.runner.withArguments(
-        ":dokkatooGeneratePublicationHtml",
-        "--stacktrace",
-        "--info",
-        "--build-cache",
-      ).forwardOutput()
+      dokkatooProject.runner
+        .withArguments(
+          ":dokkatooGeneratePublicationHtml",
+          "--stacktrace",
+          "--info",
+          "--build-cache",
+        )
+        .forwardOutput()
         .build().should { dokkatooBuildCache ->
 
           dokkatooBuildCache.output shouldContainAll listOf(
@@ -135,7 +139,8 @@ class GradleExampleTest : FunSpec({
           "--info",
           "--no-build-cache",
           "--configuration-cache",
-        ).forwardOutput()
+        )
+        .forwardOutput()
         .build()
 
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
@@ -40,8 +40,7 @@ class GradleExampleTest : FunSpec({
           "dokkaHtml",
           "--stacktrace",
           "--info",
-        )
-        //.forwardOutput()
+        ).forwardOutput()
         .build()
 
       dokkaBuild.output shouldContain "BUILD SUCCESSFUL"
@@ -55,8 +54,7 @@ class GradleExampleTest : FunSpec({
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--info",
-        )
-        //.forwardOutput()
+        ).forwardOutput()
         .build()
 
 
@@ -137,8 +135,7 @@ class GradleExampleTest : FunSpec({
           "--info",
           "--no-build-cache",
           "--configuration-cache",
-        )
-        //.forwardOutput()
+        ).forwardOutput()
         .build()
 
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
@@ -1,11 +1,20 @@
 package dev.adamko.dokkatoo.tests.examples
 
-import dev.adamko.dokkatoo.utils.*
+import dev.adamko.dokkatoo.utils.GradleProjectTest
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
+import dev.adamko.dokkatoo.utils.buildGradleKts
+import dev.adamko.dokkatoo.utils.copyExampleProject
+import dev.adamko.dokkatoo.utils.findFiles
+import dev.adamko.dokkatoo.utils.shouldContainAll
+import dev.adamko.dokkatoo.utils.sideBySide
+import dev.adamko.dokkatoo.utils.toTreeString
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.file.shouldBeAFile
 import io.kotest.matchers.file.shouldHaveSameStructureAndContentAs
 import io.kotest.matchers.file.shouldHaveSameStructureAs
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.sequences.shouldHaveCount
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -32,7 +41,7 @@ class GradleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
+        //.forwardOutput()
         .build()
 
       dokkaBuild.output shouldContain "BUILD SUCCESSFUL"
@@ -47,11 +56,17 @@ class GradleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
+        //.forwardOutput()
         .build()
 
+
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"
-      dokkatooBuild.output shouldContain "Generation completed successfully"
+
+      val dokkaWorkerLogs = dokkatooProject.findFiles { it.name == "dokka-worker.log" }
+      dokkaWorkerLogs shouldHaveCount 1
+      val dokkaWorkerLog = dokkaWorkerLogs.first()
+      dokkaWorkerLog.shouldNotBeNull().shouldBeAFile()
+      dokkaWorkerLog.readText() shouldContain "Generation completed successfully"
     }
 
     context("expect dokka and dokkatoo HTML is the same") {
@@ -71,6 +86,8 @@ class GradleExampleTest : FunSpec({
       }
     }
   }
+
+
   context("Gradle caching") {
     test("expect Dokkatoo is compatible with Gradle Build Cache") {
       val dokkatooBuild = dokkatooProject.runner
@@ -80,11 +97,16 @@ class GradleExampleTest : FunSpec({
           "--info",
           "--stacktrace",
         )
-        .forwardOutput()
+        //.forwardOutput()
         .build()
 
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"
-      dokkatooBuild.output shouldContain "Generation completed successfully"
+
+      val dokkaWorkerLogs = dokkatooProject.findFiles { it.name == "dokka-worker.log" }
+      dokkaWorkerLogs shouldHaveCount 1
+      val dokkaWorkerLog = dokkaWorkerLogs.first()
+      dokkaWorkerLog.shouldNotBeNull().shouldBeAFile()
+      dokkaWorkerLog.readText() shouldContain "Generation completed successfully"
 
       dokkatooProject.runner.withArguments(
         ":dokkatooGeneratePublicationHtml",
@@ -116,7 +138,7 @@ class GradleExampleTest : FunSpec({
           "--no-build-cache",
           "--configuration-cache",
         )
-        .forwardOutput()
+        //.forwardOutput()
         .build()
 
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
@@ -43,7 +43,8 @@ class MultimoduleExampleTest : FunSpec({
           "dokkaHtmlMultiModule",
           "--stacktrace",
           "--info",
-        ).forwardOutput()
+        )
+        .forwardOutput()
         .build()
 
       dokkaBuild.output shouldContain "BUILD SUCCESSFUL"
@@ -57,7 +58,8 @@ class MultimoduleExampleTest : FunSpec({
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--info",
-        ).forwardOutput()
+        )
+        .forwardOutput()
         .build()
 
       test("expect build is successful") {
@@ -106,7 +108,8 @@ class MultimoduleExampleTest : FunSpec({
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--info",
           "--stacktrace",
-        ).forwardOutput()
+        )
+        .forwardOutput()
         .build()
 
 
@@ -128,12 +131,14 @@ class MultimoduleExampleTest : FunSpec({
       }
 
       test("expect tasks are UP-TO-DATE") {
-        dokkatooProject.runner.withArguments(
-          ":parentProject:dokkatooGeneratePublicationHtml",
-          "--stacktrace",
-          "--info",
-          "--build-cache",
-        ).forwardOutput()
+        dokkatooProject.runner
+          .withArguments(
+            ":parentProject:dokkatooGeneratePublicationHtml",
+            "--stacktrace",
+            "--info",
+            "--build-cache",
+          )
+          .forwardOutput()
           .build().should { dokkatooBuildCache ->
 
             dokkatooBuildCache.output shouldContainAll listOf(
@@ -158,7 +163,8 @@ class MultimoduleExampleTest : FunSpec({
           "--info",
           "--no-build-cache",
           "--configuration-cache",
-        ).forwardOutput()
+        )
+        .forwardOutput()
         .build()
 
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
@@ -1,11 +1,23 @@
 package dev.adamko.dokkatoo.tests.examples
 
-import dev.adamko.dokkatoo.utils.*
+import dev.adamko.dokkatoo.utils.GradleProjectTest
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
+import dev.adamko.dokkatoo.utils.buildGradleKts
+import dev.adamko.dokkatoo.utils.copyExampleProject
+import dev.adamko.dokkatoo.utils.dir
+import dev.adamko.dokkatoo.utils.findFiles
+import dev.adamko.dokkatoo.utils.invariantNewlines
+import dev.adamko.dokkatoo.utils.settingsGradleKts
+import dev.adamko.dokkatoo.utils.shouldContainAll
+import dev.adamko.dokkatoo.utils.shouldNotContainAnyOf
+import dev.adamko.dokkatoo.utils.sideBySide
+import dev.adamko.dokkatoo.utils.toTreeString
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.file.shouldBeAFile
 import io.kotest.matchers.file.shouldHaveSameStructureAndContentAs
 import io.kotest.matchers.file.shouldHaveSameStructureAs
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -32,26 +44,40 @@ class MultimoduleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
+        //.forwardOutput()
         .build()
 
       dokkaBuild.output shouldContain "BUILD SUCCESSFUL"
       dokkaBuild.output shouldContain "Generation completed successfully"
     }
 
-    test("expect dokkatoo can generate HTML") {
-      val dokkatooBuild = dokkatooProject.runner
+    context("when Dokkatoo generates HTML") {
+      val build = dokkatooProject.runner
         .withArguments(
           "clean",
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
+        //.forwardOutput()
         .build()
 
-      dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"
-      dokkatooBuild.output shouldContain "Generation completed successfully"
+      test("expect build is successful") {
+        build.output shouldContain "BUILD SUCCESSFUL"
+      }
+
+      test("expect all dokka workers are successful") {
+        build.output.invariantNewlines() shouldContain "BUILD SUCCESSFUL"
+        val dokkaWorkerLogs = dokkatooProject.findFiles { it.name == "dokka-worker.log" }
+//      dokkaWorkerLogs shouldHaveCount 1
+        dokkaWorkerLogs.firstOrNull().shouldNotBeNull().should { dokkaWorkerLog ->
+          dokkaWorkerLog.shouldBeAFile()
+          dokkaWorkerLog.readText().shouldNotContainAnyOf(
+            "[ERROR]",
+            "[WARN]",
+          )
+        }
+      }
     }
 
     context("expect dokka and dokkatoo HTML is the same") {
@@ -72,39 +98,59 @@ class MultimoduleExampleTest : FunSpec({
       }
     }
   }
+
+
   context("Gradle caching") {
-    test("expect Dokkatoo is compatible with Gradle Build Cache") {
-      val dokkatooBuild = dokkatooProject.runner
+    context("expect Dokkatoo is compatible with Gradle Build Cache") {
+      val build = dokkatooProject.runner
         .withArguments(
           "clean",
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--info",
           "--stacktrace",
         )
-        .forwardOutput()
+        //.forwardOutput()
         .build()
 
-      dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"
-      dokkatooBuild.output shouldContain "Generation completed successfully"
 
-      dokkatooProject.runner.withArguments(
-        ":parentProject:dokkatooGeneratePublicationHtml",
-        "--stacktrace",
-        "--info",
-        "--build-cache",
-      ).forwardOutput()
-        .build().should { dokkatooBuildCache ->
+      test("expect build is successful") {
+        build.output shouldContain "BUILD SUCCESSFUL"
+      }
 
-          dokkatooBuildCache.output shouldContainAll listOf(
-            "> Task :parentProject:prepareDokkatooParametersHtml UP-TO-DATE",
-            "> Task :parentProject:dokkatooGeneratePublicationHtml UP-TO-DATE",
-            "BUILD SUCCESSFUL",
-            "8 actionable tasks: 8 up-to-date",
+      test("expect all dokka workers are successful") {
+        build.output.invariantNewlines() shouldContain "BUILD SUCCESSFUL"
+        val dokkaWorkerLogs = dokkatooProject.findFiles { it.name == "dokka-worker.log" }
+//      dokkaWorkerLogs shouldHaveCount 1
+        dokkaWorkerLogs.firstOrNull().shouldNotBeNull().should { dokkaWorkerLog ->
+          dokkaWorkerLog.shouldBeAFile()
+          dokkaWorkerLog.readText().shouldNotContainAnyOf(
+            "[ERROR]",
+            "[WARN]",
           )
-          withClue("Dokka Generator should not be triggered, so check it doesn't log anything") {
-            dokkatooBuildCache.output shouldNotContain "Generation completed successfully"
-          }
         }
+      }
+
+      test("expect tasks are UP-TO-DATE") {
+        dokkatooProject.runner.withArguments(
+          ":parentProject:dokkatooGeneratePublicationHtml",
+          "--stacktrace",
+          "--info",
+          "--build-cache",
+        )
+          //.forwardOutput()
+          .build().should { dokkatooBuildCache ->
+
+            dokkatooBuildCache.output shouldContainAll listOf(
+              "> Task :parentProject:prepareDokkatooParametersHtml UP-TO-DATE",
+              "> Task :parentProject:dokkatooGeneratePublicationHtml UP-TO-DATE",
+              "BUILD SUCCESSFUL",
+              "8 actionable tasks: 8 up-to-date",
+            )
+            withClue("Dokka Generator should not be triggered, so check it doesn't log anything") {
+              dokkatooBuildCache.output shouldNotContain "Generation completed successfully"
+            }
+          }
+      }
     }
 
     xtest("expect Dokkatoo is compatible with Gradle Configuration Cache") {
@@ -117,7 +163,7 @@ class MultimoduleExampleTest : FunSpec({
           "--no-build-cache",
           "--configuration-cache",
         )
-        .forwardOutput()
+        //.forwardOutput()
         .build()
 
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
@@ -43,8 +43,7 @@ class MultimoduleExampleTest : FunSpec({
           "dokkaHtmlMultiModule",
           "--stacktrace",
           "--info",
-        )
-        //.forwardOutput()
+        ).forwardOutput()
         .build()
 
       dokkaBuild.output shouldContain "BUILD SUCCESSFUL"
@@ -58,8 +57,7 @@ class MultimoduleExampleTest : FunSpec({
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--info",
-        )
-        //.forwardOutput()
+        ).forwardOutput()
         .build()
 
       test("expect build is successful") {
@@ -67,7 +65,7 @@ class MultimoduleExampleTest : FunSpec({
       }
 
       test("expect all dokka workers are successful") {
-        build.output.invariantNewlines() shouldContain "BUILD SUCCESSFUL"
+
         val dokkaWorkerLogs = dokkatooProject.findFiles { it.name == "dokka-worker.log" }
 //      dokkaWorkerLogs shouldHaveCount 1
         dokkaWorkerLogs.firstOrNull().shouldNotBeNull().should { dokkaWorkerLog ->
@@ -108,8 +106,7 @@ class MultimoduleExampleTest : FunSpec({
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--info",
           "--stacktrace",
-        )
-        //.forwardOutput()
+        ).forwardOutput()
         .build()
 
 
@@ -136,8 +133,7 @@ class MultimoduleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
           "--build-cache",
-        )
-          //.forwardOutput()
+        ).forwardOutput()
           .build().should { dokkatooBuildCache ->
 
             dokkatooBuildCache.output shouldContainAll listOf(
@@ -162,8 +158,7 @@ class MultimoduleExampleTest : FunSpec({
           "--info",
           "--no-build-cache",
           "--configuration-cache",
-        )
-        //.forwardOutput()
+        ).forwardOutput()
         .build()
 
       dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -48,7 +48,7 @@ class BasicProjectIntegrationTest {
         "--stacktrace",
         "--info",
       )
-      .forwardOutput()
+      //.forwardOutput()
       .withEnvironment(
         "DOKKA_VERSION" to "1.7.20",
       )
@@ -68,7 +68,7 @@ class BasicProjectIntegrationTest {
         "--stacktrace",
         "--info",
       )
-      .forwardOutput()
+      //.forwardOutput()
       .build()
 
     dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -41,8 +41,7 @@ class BasicProjectIntegrationTest : FunSpec({
         "dokkaHtml",
         "--stacktrace",
         "--info",
-      )
-      //.forwardOutput()
+      ).forwardOutput()
       .withEnvironment(
         "DOKKA_VERSION" to "1.7.20",
       )
@@ -54,8 +53,7 @@ class BasicProjectIntegrationTest : FunSpec({
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",
         "--info",
-      )
-      //.forwardOutput()
+      ).forwardOutput()
       .build()
 
     test("expect project builds successfully") {

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -1,46 +1,40 @@
 package dev.adamko.dokkatoo.tests.integration
 
 import dev.adamko.dokkatoo.utils.GradleProjectTest
-import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.integrationTestProjectsDir
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
 import dev.adamko.dokkatoo.utils.buildGradleKts
 import dev.adamko.dokkatoo.utils.copyIntegrationTestProject
+import dev.adamko.dokkatoo.utils.findFiles
 import dev.adamko.dokkatoo.utils.projectFile
 import dev.adamko.dokkatoo.utils.settingsGradleKts
 import dev.adamko.dokkatoo.utils.shouldContainAll
+import dev.adamko.dokkatoo.utils.shouldNotContainAnyOf
 import dev.adamko.dokkatoo.utils.sideBySide
 import dev.adamko.dokkatoo.utils.toTreeString
 import dev.adamko.dokkatoo.utils.withEnvironment
-import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.file.shouldBeAFile
 import io.kotest.matchers.file.shouldHaveSameStructureAndContentAs
 import io.kotest.matchers.file.shouldHaveSameStructureAs
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
 import java.io.File
-import org.junit.jupiter.api.Test
 
 /**
  * Integration test for the `it-basic` project in Dokka
  *
  * Runs Dokka & Dokkatoo, and compares the resulting HTML site.
  */
-class BasicProjectIntegrationTest {
+class BasicProjectIntegrationTest : FunSpec({
 
-  @Test
-  fun `test basic project`() {
+  val tempDir = projectTestTempDir.resolve("it/it-basic").toFile()
 
-    val basicProjectSrcDir = integrationTestProjectsDir.resolve("it-basic/dokka")
+  val dokkatooProject = initDokkatooProject(tempDir.resolve("dokkatoo"))
+  val dokkaProject = initDokkaProject(tempDir.resolve("dokka"))
 
-    val tempDir = projectTestTempDir.resolve("it/it-basic").toFile()
-
-    val dokkaDir = tempDir.resolve("dokka")
-    basicProjectSrcDir.toFile()
-      .copyRecursively(dokkaDir, overwrite = true) { _, _ -> OnErrorAction.SKIP }
-
-    val dokkaProject = initDokkaProject(dokkaDir)
-
+  context("when generating HTML") {
     val dokkaBuild = dokkaProject.runner
       .withArguments(
         "clean",
@@ -54,13 +48,6 @@ class BasicProjectIntegrationTest {
       )
       .build()
 
-    dokkaBuild.output shouldContain "BUILD SUCCESSFUL"
-    dokkaBuild.output shouldContain "Generation completed successfully"
-
-    val dokkatooDir = tempDir.resolve("dokkatoo")
-
-    val dokkatooProject = initDokkatooProject(dokkatooDir)
-
     val dokkatooBuild = dokkatooProject.runner
       .withArguments(
         "clean",
@@ -71,21 +58,61 @@ class BasicProjectIntegrationTest {
       //.forwardOutput()
       .build()
 
-    dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"
-    dokkatooBuild.output shouldContain "Generation completed successfully"
+    test("expect project builds successfully") {
+      dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"
+    }
 
-    val dokkaHtmlDir = dokkaProject.projectDir.resolve("build/dokka/html")
-    val dokkatooHtmlDir = dokkatooProject.projectDir.resolve("build/dokka/html")
+    context("with Dokka") {
 
-    val expectedFileTree = dokkaHtmlDir.toTreeString()
-    val actualFileTree = dokkatooHtmlDir.toTreeString()
-    println((actualFileTree to expectedFileTree).sideBySide())
-    expectedFileTree shouldBe actualFileTree
+      test("expect project builds successfully") {
+        dokkaBuild.output shouldContain "BUILD SUCCESSFUL"
+      }
 
-    dokkatooHtmlDir.toFile().shouldHaveSameStructureAs(dokkaHtmlDir.toFile())
-    dokkatooHtmlDir.toFile().shouldHaveSameStructureAndContentAs(dokkaHtmlDir.toFile())
+      test("expect all dokka workers are successful") {
 
-    withClue("Dokkatoo tasks should be cacheable") {
+        val dokkaWorkerLogs = dokkatooProject.findFiles { it.name == "dokka-worker.log" }
+//      dokkaWorkerLogs shouldHaveCount 1
+        dokkaWorkerLogs.firstOrNull().shouldNotBeNull().should { dokkaWorkerLog ->
+          dokkaWorkerLog.shouldBeAFile()
+          dokkaWorkerLog.readText().shouldNotContainAnyOf(
+            "[ERROR]",
+            "[WARN]",
+          )
+        }
+      }
+    }
+
+    context("with Dokkatoo") {
+
+      test("expect all dokka workers are successful") {
+
+        val dokkaWorkerLogs = dokkatooProject.findFiles { it.name == "dokka-worker.log" }
+//      dokkaWorkerLogs shouldHaveCount 1
+        dokkaWorkerLogs.firstOrNull().shouldNotBeNull().should { dokkaWorkerLog ->
+          dokkaWorkerLog.shouldBeAFile()
+          dokkaWorkerLog.readText().shouldNotContainAnyOf(
+            "[ERROR]",
+            "[WARN]",
+          )
+        }
+      }
+    }
+
+    test("expect the same HTML is generated") {
+
+      val dokkaHtmlDir = dokkaProject.projectDir.resolve("build/dokka/html")
+      val dokkatooHtmlDir = dokkatooProject.projectDir.resolve("build/dokka/html")
+
+      val expectedFileTree = dokkaHtmlDir.toTreeString()
+      val actualFileTree = dokkatooHtmlDir.toTreeString()
+      println((actualFileTree to expectedFileTree).sideBySide())
+      expectedFileTree shouldBe actualFileTree
+
+      dokkatooHtmlDir.toFile().shouldHaveSameStructureAs(dokkaHtmlDir.toFile())
+      dokkatooHtmlDir.toFile().shouldHaveSameStructureAndContentAs(dokkaHtmlDir.toFile())
+    }
+
+    test("Dokkatoo tasks should be cacheable") {
       dokkatooProject.runner.withArguments(
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",
@@ -97,14 +124,11 @@ class BasicProjectIntegrationTest {
             "Task :prepareDokkatooParametersHtml UP-TO-DATE",
             "Task :dokkatooGeneratePublicationHtml UP-TO-DATE",
           )
-          withClue("Dokka Generator should not be triggered, so check it doesn't log anything") {
-            buildResult.output shouldNotContain "Generation completed successfully"
-          }
         }
     }
 
     // TODO test configuration cache
-//    withClue("Dokkatoo tasks should be configuration-cache compatible") {
+//    test("Dokkatoo tasks should be configuration-cache compatible") {
 //      val dokkatooBuildCache =
 //        dokkatooProject.runner.withArguments(
 //          "clean",
@@ -122,7 +146,7 @@ class BasicProjectIntegrationTest {
 //      )
 //    }
   }
-}
+})
 
 
 private fun initDokkaProject(

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -41,7 +41,8 @@ class BasicProjectIntegrationTest : FunSpec({
         "dokkaHtml",
         "--stacktrace",
         "--info",
-      ).forwardOutput()
+      )
+      .forwardOutput()
       .withEnvironment(
         "DOKKA_VERSION" to "1.7.20",
       )
@@ -53,7 +54,8 @@ class BasicProjectIntegrationTest : FunSpec({
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",
         "--info",
-      ).forwardOutput()
+      )
+      .forwardOutput()
       .build()
 
     test("expect project builds successfully") {
@@ -111,12 +113,14 @@ class BasicProjectIntegrationTest : FunSpec({
     }
 
     test("Dokkatoo tasks should be cacheable") {
-      dokkatooProject.runner.withArguments(
-        "dokkatooGeneratePublicationHtml",
-        "--stacktrace",
-        "--info",
-        "--build-cache",
-      ).forwardOutput()
+      dokkatooProject.runner
+        .withArguments(
+          "dokkatooGeneratePublicationHtml",
+          "--stacktrace",
+          "--info",
+          "--build-cache",
+        )
+        .forwardOutput()
         .build().should { buildResult ->
           buildResult.output shouldContainAll listOf(
             "Task :prepareDokkatooParametersHtml UP-TO-DATE",

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -93,6 +93,7 @@ abstract class DokkatooBasePlugin @Inject constructor(
     target.tasks.withType<DokkatooGenerateTask>().configureEach {
       cacheDirectory.convention(dokkatooExtension.dokkatooCacheDirectory)
       workerDebugEnabled.convention(false)
+      workerLogFile.set(temporaryDir.resolve("dokka-worker.log"))
       // increase memory - DokkaGenerator is hungry https://github.com/Kotlin/dokka/issues/1405
       workerMinHeapSize.convention("256m")
       workerMaxHeapSize.convention("1g")

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -97,7 +97,14 @@ abstract class DokkatooBasePlugin @Inject constructor(
       // increase memory - DokkaGenerator is hungry https://github.com/Kotlin/dokka/issues/1405
       workerMinHeapSize.convention("256m")
       workerMaxHeapSize.convention("1g")
-      workerJvmArgs.set(listOf("-XX:MaxMetaspaceSize=512m"))
+      workerJvmArgs.set(
+        listOf(
+          "-XX:MaxMetaspaceSize=512m",
+          "-XX:+HeapDumpOnOutOfMemoryError",
+          //"-XX:StartFlightRecording=disk=true,name={path.drop(1).map { if (it.isLetterOrDigit()) it else '-' }.joinToString("")},dumponexit=true,duration=30s",
+          //"-XX:FlightRecorderOptions=repository=$baseDir/jfr,stackdepth=512",
+        )
+      )
     }
 
     target.tasks.withType<DokkatooPrepareModuleDescriptorTask>().all task@{

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -70,6 +70,10 @@ abstract class DokkatooGenerateTask @Inject constructor(
   @get:Input
   abstract val workerJvmArgs: ListProperty<String>
 
+  //  @get:Internal
+  @get:LocalState
+  abstract val workerLogFile: RegularFileProperty
+
   enum class GenerationType {
     MODULE,
     PUBLICATION,
@@ -115,6 +119,7 @@ abstract class DokkatooGenerateTask @Inject constructor(
 
     workQueue.submit(DokkaGeneratorWorker::class) worker@{
       this@worker.dokkaParameters.set(dokkaParameters)
+      this@worker.logFile.set(workerLogFile)
     }
   }
 

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -227,6 +227,10 @@ fun ProjectDirectoryScope.file(
 ): Path = projectDir.resolve(path)
 
 
+fun ProjectDirectoryScope.findFiles(matcher: (File) -> Boolean): Sequence<File> =
+  projectDir.toFile().walk().filter(matcher)
+
+
 /** Set the content of `settings.gradle.kts` */
 @delegate:Language("kts")
 var ProjectDirectoryScope.settingsGradleKts: String by TestProjectFileDelegate("settings.gradle.kts")
@@ -251,10 +255,10 @@ var ProjectDirectoryScope.buildGradle: String by TestProjectFileDelegate("build.
 @delegate:Language("properties")
 var ProjectDirectoryScope.gradleProperties: String by TestProjectFileDelegate("gradle.properties")
 
-fun GradleProjectTest.createKotlinFile(filePath: String, @Language("kotlin") contents: String) =
+fun ProjectDirectoryScope.createKotlinFile(filePath: String, @Language("kotlin") contents: String) =
   createFile(filePath, contents)
 
-fun GradleProjectTest.createKtsFile(filePath: String, @Language("kts") contents: String) =
+fun ProjectDirectoryScope.createKtsFile(filePath: String, @Language("kts") contents: String) =
   createFile(filePath, contents)
 
 

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/kotestStringMatchers.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/kotestStringMatchers.kt
@@ -34,3 +34,32 @@ private fun containAll(substrings: Iterable<String>) =
       { "${value.print().value} should include substrings ${substrings.print().value}" },
       { "${value.print().value} should not include substrings ${substrings.print().value}" })
   }
+
+
+infix fun String?.shouldContainAnyOf(substrings: Iterable<String>): String? {
+  this should containAnyOf(substrings)
+  return this
+}
+
+infix fun String?.shouldNotContainAnyOf(substrings: Iterable<String>): String? {
+  this shouldNot containAnyOf(substrings)
+  return this
+}
+
+fun String?.shouldContainAnyOf(vararg substrings: String): String? {
+  this should containAnyOf(substrings.asList())
+  return this
+}
+
+fun String?.shouldNotContainAnyOf(vararg substrings: String): String? {
+  this shouldNot containAnyOf(substrings.asList())
+  return this
+}
+
+private fun containAnyOf(substrings: Iterable<String>) =
+  neverNullMatcher<String> { value ->
+    MatcherResult(
+      substrings.any { it in value },
+      { "${value.print().value} should include any of these substrings ${substrings.print().value}" },
+      { "${value.print().value} should not include any of these substrings ${substrings.print().value}" })
+  }

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -22,7 +22,7 @@ class MultiModuleFunctionalTest : FunSpec({
   context("when dokkatoo generates all formats") {
     val build = project.runner
       .withArguments("clean", ":dokkatooGenerate", "--stacktrace", "--info")
-      //.forwardOutput()
+      .forwardOutput()
       .build()
 
 

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -2,24 +2,137 @@ package dev.adamko.dokkatoo
 
 import dev.adamko.dokkatoo.dokka.parameters.DokkaParametersKxs
 import dev.adamko.dokkatoo.utils.*
-import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContainAnyOf
+import io.kotest.matchers.file.shouldBeAFile
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.paths.shouldBeAFile
 import io.kotest.matchers.paths.shouldExist
+import io.kotest.matchers.should
 import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.decodeFromStream
-import org.junit.jupiter.api.Test
 
-class MultiModuleFunctionalTest {
+class MultiModuleFunctionalTest : FunSpec({
 
-  private val project = gradleKtsProjectTest("multi-module-hello-goodbye") {
+  val project = initDokkatooProject()
+
+
+  context("when dokkatoo generates all formats") {
+    val build = project.runner
+      .withArguments("clean", ":dokkatooGenerate", "--stacktrace", "--info")
+      //.forwardOutput()
+      .build()
+
+
+    test("expect build is successful") {
+      build.output shouldContain "BUILD SUCCESSFUL"
+    }
+
+    test("expect all dokka workers are successful") {
+      val dokkaWorkerLogs = project.findFiles { it.name == "dokka-worker.log" }
+//      dokkaWorkerLogs shouldHaveCount 1
+      dokkaWorkerLogs.firstOrNull().shouldNotBeNull().should { dokkaWorkerLog ->
+        dokkaWorkerLog.shouldBeAFile()
+        dokkaWorkerLog.readText().shouldNotContainAnyOf(
+          "[ERROR]",
+          "[WARN]",
+        )
+      }
+    }
+
+    context("expect HTML site is generated") {
+
+      test("with expected HTML files") {
+        project.projectDir.resolve("subproject/build/dokka/html/index.html").shouldBeAFile()
+        project.projectDir.resolve("subproject/build/dokka/html/com/project/hello/Hello.html")
+          .shouldBeAFile()
+      }
+
+      test("and dokka_parameters.json is generated") {
+        project.projectDir.resolve("subproject/build/dokka/html/dokka_parameters.json")
+          .shouldBeAFile()
+      }
+
+      test("with element-list") {
+        project.projectDir.resolve("build/dokka/html/package-list").shouldBeAFile()
+        project.projectDir.resolve("build/dokka/html/package-list").toFile().readText()
+          .shouldContain( // language=text
+            """
+              |${'$'}dokka.format:html-v1
+              |${'$'}dokka.linkExtension:html
+              |
+              |module:subproject-hello
+              |com.project.hello
+              |module:subproject-goodbye
+              |com.project.goodbye
+            """.trimMargin()
+          )
+      }
+    }
+
+
+//        project.projectDir.toFile().walk().forEach { println(it) }
+
+//        project.projectDir.resolve("subproject/build/dokka-output/com/project/hello/Hello.html").shouldBeAFile()
+//        project.projectDir.resolve("subproject/build/dokka-output/index.html").shouldBeAFile()
+//        project.projectDir.resolve("subproject/build/dokka-config/dokka_parameters.json").shouldBeAFile()
+//        project.projectDir.resolve("subproject/build/dokka-output/element-list").shouldBeAFile()
+//        project.projectDir.resolve("subproject/build/dokka-output/element-list").toFile().readText().shouldContain(
+//            """
+//            ${'$'}dokka.format:javadoc-v1
+//            ${'$'}dokka.linkExtension:html
+//
+//            com.project.hello
+//        """.trimIndent()
+//        )
+
+    val dokkaConfigurationFile =
+      project.projectDir.resolve("build/dokka-config/html/dokka_parameters.json")
+    dokkaConfigurationFile.shouldExist()
+    dokkaConfigurationFile.shouldBeAFile()
+    @OptIn(ExperimentalSerializationApi::class)
+    val dokkaConfiguration = kotlinx.serialization.json.Json.decodeFromStream(
+      DokkaParametersKxs.serializer(),
+      dokkaConfigurationFile.toFile().inputStream(),
+    )
+
+    context("expect pluginsClasspath") {
+      val pluginClasspathJars = dokkaConfiguration.pluginsClasspath.map { it.name }
+
+      test("does not contain subproject jars") {
+        pluginClasspathJars.shouldNotContainAnyOf(
+          "subproject-hello.jar",
+          "subproject-goodbye.jar",
+        )
+      }
+
+      test("contains the default Dokka plugins") {
+        pluginClasspathJars.shouldContainExactlyInAnyOrder(
+//        "markdown-jvm-0.3.1.jar",
+          "kotlin-analysis-intellij-1.7.20.jar",
+          "dokka-base-1.7.20.jar",
+          "templating-plugin-1.7.20.jar",
+          "dokka-analysis-1.7.20.jar",
+          "kotlin-analysis-compiler-1.7.20.jar",
+          "kotlinx-html-jvm-0.8.0.jar",
+          "freemarker-2.3.31.jar",
+          "all-modules-page-plugin-1.7.20.jar",
+        )
+      }
+    }
+  }
+})
+
+private fun initDokkatooProject(): GradleProjectTest {
+  return gradleKtsProjectTest("multi-module-hello-goodbye") {
 
     settingsGradleKts += """
       |
       |include(":subproject-hello")
       |include(":subproject-goodbye")
+      |
     """.trimMargin()
 
     buildGradleKts = """
@@ -28,15 +141,16 @@ class MultiModuleFunctionalTest {
       |//import org.jetbrains.dokka.*
       |
       |plugins {
-      |    // Kotlin plugin shouldn't be necessary here, but without it Dokka errors
-      |    // with ClassNotFound KotlinPluginExtension... very weird
-      |    kotlin("jvm") version "1.7.20" apply false
-      |    id("dev.adamko.dokkatoo") version "0.0.2-SNAPSHOT"
+      |  // Kotlin plugin shouldn't be necessary here, but without it Dokka errors
+      |  // with ClassNotFound KotlinPluginExtension... very weird
+      |  kotlin("jvm") version "1.7.20" apply false
+      |  id("dev.adamko.dokkatoo") version "0.0.2-SNAPSHOT"
       |}
       |
       |dependencies {
-      |    dokkatoo(project(":subproject-hello"))
-      |    dokkatoo(project(":subproject-goodbye"))
+      |  dokkatoo(project(":subproject-hello"))
+      |  dokkatoo(project(":subproject-goodbye"))
+      |  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin:1.7.20")
       |}
       |
       |//tasks.withType<DokkaConfigurationTask>().configureEach {
@@ -66,214 +180,117 @@ class MultiModuleFunctionalTest {
       |//        )
       |//    )
       |//}
+      |
     """.trimMargin()
 
-    //createKotlinFile(
-    //  "src/main/kotlin/Dummy.kt",
-    //    """
-    //      |package com.project.dummy
-    //      |
-    //      |/** Dummy class - this is only here to trigger Dokka */
-    //      |class Dummy {
-    //      |    val nothing: String = ""
-    //      |}
-    //      |
-    //    """.trimMargin()
-    //)
+    dir("subproject-hello") {
+      buildGradleKts = """
+          |//import org.jetbrains.dokka.gradle.tasks.DokkaConfigurationTask
+          |//import org.jetbrains.dokka.gradle.dokka_configuration.DokkaConfigurationKxs
+          |//import org.jetbrains.dokka.*
+          |
+          |plugins {
+          |    kotlin("jvm") version "1.7.20"
+          |    id("dev.adamko.dokkatoo") version "0.0.2-SNAPSHOT"
+          |}
+          |
+          |// TODO copy the DSL from the old plugin
+          |//tasks.withType<DokkaConfigurationTask>().configureEach {
+          |    //dokkaSourceSets.create("Hello Subproject") {
+          |       // sourceSetID = DokkaSourceSetID("moduleName", "main")
+          |       // classpath = emptyList()
+          |       // sourceRoots = setOf(file("src/main/kotlin"))
+          |       // dependentSourceSets = emptySet()
+          |       // samples = emptySet()
+          |       // includes = emptySet()
+          |       // documentedVisibilities = DokkaConfiguration.Visibility.values().toSet()
+          |       // reportUndocumented = false
+          |       // skipEmptyPackages = true
+          |       // skipDeprecated = false
+          |       // jdkVersion = 8
+          |       // sourceLinks = emptySet()
+          |       // perPackageOptions = emptyList()
+          |       // externalDocumentationLinks = emptySet()
+          |       // languageVersion = null
+          |       // apiVersion = null
+          |       // noStdlibLink = false
+          |       // noJdkLink = false
+          |       // suppressedFiles = emptySet()
+          |       // analysisPlatform = org.jetbrains.dokka.Platform.DEFAULT
+          |    //}
+          |//}
+        """.trimMargin()
 
-    createKtsFile(
-      "subproject-hello/build.gradle.kts",
-      """
-        |//import org.jetbrains.dokka.gradle.tasks.DokkaConfigurationTask
-        |//import org.jetbrains.dokka.gradle.dokka_configuration.DokkaConfigurationKxs
-        |//import org.jetbrains.dokka.*
-        |
-        |plugins {
-        |    kotlin("jvm") version "1.7.20"
-        |    id("dev.adamko.dokkatoo") version "0.0.2-SNAPSHOT"
-        |}
-        |
-        |// TODO copy the DSL from the old plugin
-        |//tasks.withType<DokkaConfigurationTask>().configureEach {
-        |    //dokkaSourceSets.create("Hello Subproject") {
-        |       // sourceSetID = DokkaSourceSetID("moduleName", "main")
-        |       // classpath = emptyList()
-        |       // sourceRoots = setOf(file("src/main/kotlin"))
-        |       // dependentSourceSets = emptySet()
-        |       // samples = emptySet()
-        |       // includes = emptySet()
-        |       // documentedVisibilities = DokkaConfiguration.Visibility.values().toSet()
-        |       // reportUndocumented = false
-        |       // skipEmptyPackages = true
-        |       // skipDeprecated = false
-        |       // jdkVersion = 8
-        |       // sourceLinks = emptySet()
-        |       // perPackageOptions = emptyList()
-        |       // externalDocumentationLinks = emptySet()
-        |       // languageVersion = null
-        |       // apiVersion = null
-        |       // noStdlibLink = false
-        |       // noJdkLink = false
-        |       // suppressedFiles = emptySet()
-        |       // analysisPlatform = org.jetbrains.dokka.Platform.DEFAULT
-        |    //}
-        |//}
-      """.trimMargin()
-    )
-
-    createKotlinFile(
-      "subproject-hello/src/main/kotlin/Hello.kt",
-      """
-        |package com.project.hello
-        |
-        |/** The Hello class */
-        |class Hello {
-        |    /** prints `Hello` to the console */  
-        |    fun sayHello() = println("Hello")
-        |}
-      """.trimMargin()
-    )
-
-    createKtsFile(
-      "subproject-goodbye/build.gradle.kts",
-      """
-        |
-        |//import org.jetbrains.dokka.gradle.tasks.DokkaConfigurationTask
-        |//import org.jetbrains.dokka.gradle.dokka_configuration.DokkaConfigurationKxs
-        |//import org.jetbrains.dokka.*
-        |
-        |plugins {
-        |    kotlin("jvm") version "1.7.20"
-        |    id("dev.adamko.dokkatoo") version "0.0.2-SNAPSHOT"
-        |}
-        |
-        |logger.lifecycle("with kotlin extension " + kotlin::class.toString())
-        |
-        |//tasks.withType<DokkaConfigurationTask>().configureEach {
-        |   // dokkaSourceSets.create("Goodbye Subproject") {}
-        |//    sourceSets.add(
-        |//        DokkaConfigurationKxs.DokkaSourceSetKxs(
-        |//            displayName = "My Subproject",
-        |//            sourceSetID = DokkaSourceSetID("moduleName", "main"),
-        |//            classpath = emptyList(),
-        |//            sourceRoots = setOf(file("src/main/kotlin")),
-        |//            dependentSourceSets = emptySet(),
-        |//            samples = emptySet(),
-        |//            includes = emptySet(),
-        |//            documentedVisibilities = DokkaConfiguration.Visibility.values().toSet(),
-        |//            reportUndocumented = false,
-        |//            skipEmptyPackages = true,
-        |//            skipDeprecated = false,
-        |//            jdkVersion = 8,
-        |//            sourceLinks = emptySet(),
-        |//            perPackageOptions = emptyList(),
-        |//            externalDocumentationLinks = emptySet(),
-        |//            languageVersion = null,
-        |//            apiVersion = null,
-        |//            noStdlibLink = false,
-        |//            noJdkLink = false,
-        |//            suppressedFiles = emptySet(),
-        |//            analysisPlatform = org.jetbrains.dokka.Platform.DEFAULT,
-        |//        )
-        |//    )
-        |//}
-    """.trimMargin()
-    )
-
-    createKotlinFile(
-      "subproject-goodbye/src/main/kotlin/Goodbye.kt",
-      """
-        |package com.project.goodbye
-        |
-        |/** The Goodbye class */
-        |class Goodbye {
-        |    /** prints a goodbye message to the console */  
-        |    fun sayHello() = println("Goodbye!")
-        |}
-      """.trimMargin()
-    )
-  }
-
-  //    @Test
-  fun `expect subproject generates JavaDoc site`() {
-    val build = project.runner
-      .withArguments(":subproject:dokkaGenerate", "--stacktrace", "--info")
-      .forwardOutput()
-      .build()
-
-    build.output.invariantNewlines() shouldContain "BUILD SUCCESSFUL"
-    build.output.invariantNewlines() shouldContain "Generation completed successfully"
-
-
-    project.projectDir.resolve("subproject/build/dokka/html/com/project/hello/Hello.html")
-      .shouldBeAFile()
-    project.projectDir.resolve("subproject/build/dokka/html/index.html").shouldBeAFile()
-    project.projectDir.resolve("subproject/build/dokka/html/dokka_parameters.json")
-      .shouldBeAFile()
-    project.projectDir.resolve("subproject/build/dokka/html/element-list").shouldBeAFile()
-    project.projectDir.resolve("subproject/build/dokka/html/element-list").toFile().readText()
-      .shouldContain(
+      createKotlinFile(
+        "src/main/kotlin/Hello.kt",
         """
-            ${'$'}dokka.format:javadoc-v1
-            ${'$'}dokka.linkExtension:html
-
-            com.project.hello
-        """.trimIndent()
+          |package com.project.hello
+          |
+          |/** The Hello class */
+          |class Hello {
+          |    /** prints `Hello` to the console */  
+          |    fun sayHello() = println("Hello")
+          |}
+        """.trimMargin()
       )
-  }
+    }
 
-  @Test
-  fun `expect root project aggregates`() {
-    val build = project.runner
-      .withArguments("clean", ":dokkaGenerate", "--stacktrace", "--info")
-      .forwardOutput()
-      .build()
+    dir("subproject-goodbye") {
 
-    build.output.invariantNewlines() shouldContain "BUILD SUCCESSFUL"
-    build.output.invariantNewlines() shouldContain "Generation completed successfully"
+      buildGradleKts = """
+          |
+          |//import org.jetbrains.dokka.gradle.tasks.DokkaConfigurationTask
+          |//import org.jetbrains.dokka.gradle.dokka_configuration.DokkaConfigurationKxs
+          |//import org.jetbrains.dokka.*
+          |
+          |plugins {
+          |    kotlin("jvm") version "1.7.20"
+          |    id("dev.adamko.dokkatoo") version "0.0.2-SNAPSHOT"
+          |}
+          |
+          |logger.lifecycle("with kotlin extension " + kotlin::class.toString())
+          |
+          |//tasks.withType<DokkaConfigurationTask>().configureEach {
+          |   // dokkaSourceSets.create("Goodbye Subproject") {}
+          |//    sourceSets.add(
+          |//        DokkaConfigurationKxs.DokkaSourceSetKxs(
+          |//            displayName = "My Subproject",
+          |//            sourceSetID = DokkaSourceSetID("moduleName", "main"),
+          |//            classpath = emptyList(),
+          |//            sourceRoots = setOf(file("src/main/kotlin")),
+          |//            dependentSourceSets = emptySet(),
+          |//            samples = emptySet(),
+          |//            includes = emptySet(),
+          |//            documentedVisibilities = DokkaConfiguration.Visibility.values().toSet(),
+          |//            reportUndocumented = false,
+          |//            skipEmptyPackages = true,
+          |//            skipDeprecated = false,
+          |//            jdkVersion = 8,
+          |//            sourceLinks = emptySet(),
+          |//            perPackageOptions = emptyList(),
+          |//            externalDocumentationLinks = emptySet(),
+          |//            languageVersion = null,
+          |//            apiVersion = null,
+          |//            noStdlibLink = false,
+          |//            noJdkLink = false,
+          |//            suppressedFiles = emptySet(),
+          |//            analysisPlatform = org.jetbrains.dokka.Platform.DEFAULT,
+          |//        )
+          |//    )
+          |//}
+        """.trimMargin()
 
-//        project.projectDir.toFile().walk().forEach { println(it) }
-
-//        project.projectDir.resolve("subproject/build/dokka-output/com/project/hello/Hello.html").shouldBeAFile()
-//        project.projectDir.resolve("subproject/build/dokka-output/index.html").shouldBeAFile()
-//        project.projectDir.resolve("subproject/build/dokka-config/dokka_parameters.json").shouldBeAFile()
-//        project.projectDir.resolve("subproject/build/dokka-output/element-list").shouldBeAFile()
-//        project.projectDir.resolve("subproject/build/dokka-output/element-list").toFile().readText().shouldContain(
-//            """
-//            ${'$'}dokka.format:javadoc-v1
-//            ${'$'}dokka.linkExtension:html
-//
-//            com.project.hello
-//        """.trimIndent()
-//        )
-
-    val dokkaConfigurationFile =
-      project.projectDir.resolve("build/dokka-config/html/dokka_parameters.json")
-    dokkaConfigurationFile.shouldExist()
-    dokkaConfigurationFile.shouldBeAFile()
-    @OptIn(ExperimentalSerializationApi::class)
-    val dokkaConfiguration = kotlinx.serialization.json.Json.decodeFromStream(
-      DokkaParametersKxs.serializer(),
-      dokkaConfigurationFile.toFile().inputStream(),
-    )
-
-    withClue("pluginsClasspath should not contain subproject jars") {
-      val pluginClasspathJars = dokkaConfiguration.pluginsClasspath.map { it.name }
-
-      pluginClasspathJars.shouldNotContainAnyOf(
-        "subproject-hello.jar",
-        "subproject-goodbye.jar",
-      )
-
-      pluginClasspathJars.shouldContainExactlyInAnyOrder(
-//        "markdown-jvm-0.3.1.jar",
-        "kotlin-analysis-intellij-1.7.20.jar",
-        "dokka-base-1.7.20.jar",
-        "templating-plugin-1.7.20.jar",
-        "dokka-analysis-1.7.20.jar",
-        "kotlin-analysis-compiler-1.7.20.jar",
-        "kotlinx-html-jvm-0.8.0.jar",
-        "freemarker-2.3.31.jar"
+      createKotlinFile(
+        "src/main/kotlin/Goodbye.kt",
+        """
+          |package com.project.goodbye
+          |
+          |/** The Goodbye class */
+          |class Goodbye {
+          |    /** prints a goodbye message to the console */  
+          |    fun sayHello() = println("Goodbye!")
+          |}
+        """.trimMargin()
       )
     }
   }


### PR DESCRIPTION
Gradle has OOM issues when there is a lot of console output. Hopefully logging to file improves performance.