### PR TITLE
refactor configuration & task names to be specific to each `DokkatooFormatPlugin`

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
@@ -1,19 +1,6 @@
 package dev.adamko.dokkatoo.dokka
 
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_MODULE_FILES_CONSUMER
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_MODULE_FILES_PROVIDER
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_PARAMETERS
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKATOO_PARAMETERS_OUTGOING
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKA_GENERATOR_CLASSPATH
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKA_PLUGINS_CLASSPATH
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKA_PLUGINS_CLASSPATH_OUTGOING
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.ConfigurationName.DOKKA_PLUGINS_INTRANSITIVE_CLASSPATH
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.GENERATE_MODULE
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.GENERATE_PUBLICATION
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.PREPARE_MODULE_DESCRIPTOR
-import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.TaskName.PREPARE_PARAMETERS
 import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec
-import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import java.io.Serializable
 import javax.inject.Inject
 import org.gradle.api.Named
@@ -39,9 +26,6 @@ abstract class DokkaPublication @Inject constructor(
 
   @Internal
   override fun getName(): String = formatName
-
-  @get:Internal
-  abstract val description: Property<String>
 
   @get:Input
   abstract val enabled: Property<Boolean>
@@ -81,10 +65,6 @@ abstract class DokkaPublication @Inject constructor(
   @get:Input
   abstract val offlineMode: Property<Boolean>
 
-//    @get:InputFiles
-//    @get:Classpath
-//    abstract val pluginsClasspath: ConfigurableFileCollection
-
   @get:Nested
   abstract val pluginsConfiguration: NamedDomainObjectContainer<DokkaPluginConfigurationSpec>
 
@@ -119,34 +99,4 @@ abstract class DokkaPublication @Inject constructor(
   @get:Input
   // TODO probably not needed any more, since Dokka Generator now runs in an isolated JVM process
   abstract val finalizeCoroutines: Property<Boolean>
-
-  @Internal
-  val taskNames = TaskNames()
-
-  @Internal
-  val configurationNames = ConfigurationNames()
-
-  private fun String.formatSuffix() = this + formatName.capitalize()
-
-  @DokkatooInternalApi
-  inner class TaskNames : Serializable {
-    val generatePublication = GENERATE_PUBLICATION.formatSuffix()
-    val generateModule = GENERATE_MODULE.formatSuffix()
-    val prepareParameters = PREPARE_PARAMETERS.formatSuffix()
-    val prepareModuleDescriptor = PREPARE_MODULE_DESCRIPTOR.formatSuffix()
-  }
-
-  // TODO rename 'outgoing' or 'provider' to 'shared'?
-
-  @DokkatooInternalApi
-  inner class ConfigurationNames : Serializable {
-    val dokkaParametersConsumer: String = DOKKATOO_PARAMETERS.formatSuffix()
-    val dokkaParametersOutgoing: String = DOKKATOO_PARAMETERS_OUTGOING.formatSuffix()
-    val moduleDescriptorFiles = DOKKATOO_MODULE_FILES_CONSUMER.formatSuffix()
-    val moduleDescriptorFilesOutgoing = DOKKATOO_MODULE_FILES_PROVIDER.formatSuffix()
-    val dokkaGeneratorClasspath = DOKKA_GENERATOR_CLASSPATH.formatSuffix()
-    val dokkaPluginsClasspath = DOKKA_PLUGINS_CLASSPATH.formatSuffix()
-    val dokkaPluginsIntransitiveClasspath = DOKKA_PLUGINS_INTRANSITIVE_CLASSPATH.formatSuffix()
-    val dokkaPluginsClasspathOutgoing = DOKKA_PLUGINS_CLASSPATH_OUTGOING.formatSuffix()
-  }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -32,11 +32,12 @@ abstract class DokkatooGenerateTask @Inject constructor(
   @get:PathSensitive(NAME_ONLY)
   abstract val dokkaParametersJson: RegularFileProperty
 
+  /**
+   * Contains both the Dokka Generator classpath and Dokka plugins, and any transitive dependencies
+   * of either.
+   */
   @get:Classpath
   abstract val runtimeClasspath: ConfigurableFileCollection
-
-//    @get:Classpath
-//    abstract val pluginClasspath: ConfigurableFileCollection
 
   @get:LocalState
   abstract val cacheDirectory: DirectoryProperty
@@ -70,7 +71,6 @@ abstract class DokkatooGenerateTask @Inject constructor(
   @get:Input
   abstract val workerJvmArgs: ListProperty<String>
 
-  //  @get:Internal
   @get:LocalState
   abstract val workerLogFile: RegularFileProperty
 

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/kotestCollectionMatchers.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/kotestCollectionMatchers.kt
@@ -1,0 +1,14 @@
+package dev.adamko.dokkatoo.utils
+
+import io.kotest.matchers.maps.shouldContainAll
+import io.kotest.matchers.maps.shouldContainExactly
+
+/** @see io.kotest.matchers.maps.shouldContainAll */
+fun <K, V> Map<K, V>.shouldContainAll(
+  vararg expected: Pair<K, V>
+): Unit = shouldContainAll(expected.toMap())
+
+/** @see io.kotest.matchers.maps.shouldContainExactly */
+fun <K, V> Map<K, V>.shouldContainExactly(
+  vararg expected: Pair<K, V>
+): Unit = shouldContainExactly(expected.toMap())

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/stringUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/stringUtils.kt
@@ -1,0 +1,4 @@
+package dev.adamko.dokkatoo.utils
+
+fun String.splitToPair(delimiter: String) =
+  substringBefore(delimiter) to substringAfter(delimiter)

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
@@ -3,62 +3,89 @@ package dev.adamko.dokkatoo
 import dev.adamko.dokkatoo.utils.buildGradleKts
 import dev.adamko.dokkatoo.utils.gradleKtsProjectTest
 import dev.adamko.dokkatoo.utils.invariantNewlines
+import dev.adamko.dokkatoo.utils.shouldContainExactly
+import dev.adamko.dokkatoo.utils.splitToPair
+import io.kotest.assertions.asClue
 import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.string.shouldContain
-import java.io.File
 import org.junit.jupiter.api.Test
 
 class DokkatooPluginFunctionalTest {
   private val testProject = gradleKtsProjectTest("DokkatooPluginFunctionalTest") {
     buildGradleKts = """
-        |plugins {
-        |    id("dev.adamko.dokkatoo") version "0.0.3-SNAPSHOT"
-        |}
-      """.trimMargin()
-  }
-
-  @Test
-  fun `expect Dokka Plugin creates Dokka tasks`() {
-    val build = testProject.runner
-      .withArguments("tasks")
-      .build()
-
-    build.output.invariantNewlines() shouldContain /* language=text */ """
-      |Dokkatoo tasks
-      |--------------
-      |dokkatooGenerate - Runs all Dokkatoo Generate tasks
-      |dokkatooGenerateModuleGfm - Executes the Dokka Generator, generating a gfm module
-      |dokkatooGenerateModuleHtml - Executes the Dokka Generator, generating a html module
-      |dokkatooGenerateModuleJavadoc - Executes the Dokka Generator, generating a javadoc module
-      |dokkatooGenerateModuleJekyll - Executes the Dokka Generator, generating a jekyll module
-      |dokkatooGeneratePublicationGfm - Executes the Dokka Generator, generating the gfm publication
-      |dokkatooGeneratePublicationHtml - Executes the Dokka Generator, generating the html publication
-      |dokkatooGeneratePublicationJavadoc - Executes the Dokka Generator, generating the javadoc publication
-      |dokkatooGeneratePublicationJekyll - Executes the Dokka Generator, generating the jekyll publication
-      |prepareDokkatooModuleDescriptorGfm - Prepares the Dokka Module Descriptor for gfm
-      |prepareDokkatooModuleDescriptorHtml - Prepares the Dokka Module Descriptor for html
-      |prepareDokkatooModuleDescriptorJavadoc - Prepares the Dokka Module Descriptor for javadoc
-      |prepareDokkatooModuleDescriptorJekyll - Prepares the Dokka Module Descriptor for jekyll
-      |prepareDokkatooParameters - Runs all Dokkatoo Create Configuration tasks
-      |prepareDokkatooParametersGfm - Creates Dokka Configuration for executing the Dokka Generator for the gfm publication
-      |prepareDokkatooParametersHtml - Creates Dokka Configuration for executing the Dokka Generator for the html publication
-      |prepareDokkatooParametersJavadoc - Creates Dokka Configuration for executing the Dokka Generator for the javadoc publication
-      |prepareDokkatooParametersJekyll - Creates Dokka Configuration for executing the Dokka Generator for the jekyll publication
+      |plugins {
+      |    id("dev.adamko.dokkatoo") version "0.0.3-SNAPSHOT"
+      |}
       |
     """.trimMargin()
   }
 
   @Test
-  fun `expect Dokka Plugin creates Dokka outgoing variants`() {
+  fun `expect Dokka Plugin creates Dokka tasks`() {
     val build = testProject.runner
-      .withArguments("outgoingVariants")
+      .withArguments("tasks", "--group=dokkatoo", "-q")
       .build()
 
+    withClue(build.output) {
+      val dokkatooTasks = build.output
+        .substringAfter("Dokkatoo tasks")
+        .lines()
+        .filter { it.contains(" - ") }
+        .associate { it.splitToPair(" - ") }
+
+      dokkatooTasks.shouldContainExactly(
+        //@formatter:off
+        "dokkatooGenerate"                       to "Generates Dokkatoo publications for all formats",
+        "dokkatooGenerateModuleGfm"              to "Executes the Dokka Generator, generating a gfm module",
+        "dokkatooGenerateModuleHtml"             to "Executes the Dokka Generator, generating a html module",
+        "dokkatooGenerateModuleJavadoc"          to "Executes the Dokka Generator, generating a javadoc module",
+        "dokkatooGenerateModuleJekyll"           to "Executes the Dokka Generator, generating a jekyll module",
+        "dokkatooGeneratePublicationGfm"         to "Executes the Dokka Generator, generating the gfm publication",
+        "dokkatooGeneratePublicationHtml"        to "Executes the Dokka Generator, generating the html publication",
+        "dokkatooGeneratePublicationJavadoc"     to "Executes the Dokka Generator, generating the javadoc publication",
+        "dokkatooGeneratePublicationJekyll"      to "Executes the Dokka Generator, generating the jekyll publication",
+        "prepareDokkatooModuleDescriptorGfm"     to "Prepares the Dokka Module Descriptor for gfm",
+        "prepareDokkatooModuleDescriptorHtml"    to "Prepares the Dokka Module Descriptor for html",
+        "prepareDokkatooModuleDescriptorJavadoc" to "Prepares the Dokka Module Descriptor for javadoc",
+        "prepareDokkatooModuleDescriptorJekyll"  to "Prepares the Dokka Module Descriptor for jekyll",
+        "prepareDokkatooParameters"              to "Prepares Dokka parameters for all formats",
+        "prepareDokkatooParametersGfm"           to "Prepares Dokka parameters for generating the gfm publication",
+        "prepareDokkatooParametersHtml"          to "Prepares Dokka parameters for generating the html publication",
+        "prepareDokkatooParametersJavadoc"       to "Prepares Dokka parameters for generating the javadoc publication",
+        "prepareDokkatooParametersJekyll"        to "Prepares Dokka parameters for generating the jekyll publication",
+        //@formatter:on
+      )
+    }
+  }
+
+  @Test
+  fun `expect Dokka Plugin creates Dokka outgoing variants`() {
+    val build = testProject.runner
+      .withArguments("outgoingVariants", "-q")
+      .build()
+
+    val variants = build.output.invariantNewlines().replace('\\', '/')
+
+    val dokkatooVariants = variants.lines()
+      .filter { it.contains("dokka", ignoreCase = true) }
+      .mapNotNull { it.substringAfter("Variant ", "").takeIf(String::isNotBlank) }
+
+    dokkatooVariants.shouldContainExactlyInAnyOrder(
+      "dokkatooParametersElementsGfm",
+      "dokkatooParametersElementsHtml",
+      "dokkatooParametersElementsJavadoc",
+      "dokkatooParametersElementsJekyll",
+      "dokkatooModuleElementsGfm",
+      "dokkatooModuleElementsHtml",
+      "dokkatooModuleElementsJavadoc",
+      "dokkatooModuleElementsJekyll",
+    )
 
     fun checkVariant(format: String) {
       val formatCapitalized = format.capitalize()
 
-      build.output.invariantNewlines() shouldContain /* language=text */ """
+      variants shouldContain /* language=text */ """
         |--------------------------------------------------
         |Variant dokkatooParametersElements$formatCapitalized
         |--------------------------------------------------
@@ -73,29 +100,9 @@ class DokkatooPluginFunctionalTest {
         |Artifacts
         |    - build/dokka-config/$format/dokka_parameters.json (artifactType = json)
         |
-      """.trimMargin().replace('/', File.separatorChar)
+      """.trimMargin()
 
-      build.output.invariantNewlines() shouldContain /* language=text */ """
-        |--------------------------------------------------
-        |Variant dokkatooPluginElements$formatCapitalized
-        |--------------------------------------------------
-        |Provide the Dokka Plugins classpath for $format to other subprojects
-        |
-        |Capabilities
-        |    - :test:unspecified (default capability)
-        |Attributes
-        |    - dev.adamko.dokkatoo.base       = dokkatoo
-        |    - dev.adamko.dokkatoo.category   = plugins-classpath
-        |    - dev.adamko.dokkatoo.format     = $format
-        |    - org.gradle.category            = library
-        |    - org.gradle.dependency.bundling = external
-        |    - org.gradle.jvm.environment     = standard-jvm
-        |    - org.gradle.libraryelements     = jar
-        |    - org.gradle.usage               = java-runtime
-        |
-      """.trimMargin().replace('/', File.separatorChar)
-
-      build.output.invariantNewlines() shouldContain /* language=text */ """
+      variants shouldContain /* language=text */ """
         |--------------------------------------------------
         |Variant dokkatooModuleElements$formatCapitalized
         |--------------------------------------------------
@@ -111,7 +118,7 @@ class DokkatooPluginFunctionalTest {
         |    - build/dokka-config/$format/module_descriptor.json (artifactType = json)
         |    - build/dokka-module/$format (artifactType = directory)
         |
-      """.trimMargin().replace('/', File.separatorChar)
+      """.trimMargin()
     }
 
     checkVariant("gfm")
@@ -122,104 +129,125 @@ class DokkatooPluginFunctionalTest {
 
   @Test
   fun `expect Dokka Plugin creates Dokka resolvable configurations`() {
+
+    val expectedFormats = listOf("Gfm", "Html", "Javadoc", "Jekyll")
+
     val build = testProject.runner
-      .withArguments("resolvableConfigurations")
+      .withArguments("resolvableConfigurations", "-q")
       .build()
 
-    withClue("Configuration dokka") {
-      build.output.invariantNewlines() shouldContain /* language=text */ """
-        |--------------------------------------------------
-        |Configuration dokkatoo
-        |--------------------------------------------------
-        |Fetch all Dokkatoo files from all configurations in other subprojects
-        |
-        |Attributes
-        |    - dev.adamko.dokkatoo.base = dokkatoo
-        |
-      """.trimMargin()
+    build.output.invariantNewlines().asClue { allConfigurations ->
+
+      val dokkatooConfigurations = allConfigurations.lines()
+        .filter { it.contains("dokka", ignoreCase = true) }
+        .mapNotNull { it.substringAfter("Configuration ", "").takeIf(String::isNotBlank) }
+
+      dokkatooConfigurations.shouldContainExactlyInAnyOrder(
+        mutableListOf<String>().apply {
+          add("dokkatoo")
+
+          addAll(expectedFormats.map { "dokkatooParameters$it" })
+          addAll(expectedFormats.map { "dokkatooModule$it" })
+          addAll(expectedFormats.map { "dokkatooGeneratorClasspath$it" })
+          addAll(expectedFormats.map { "dokkatooPlugin$it" })
+          addAll(expectedFormats.map { "dokkatooPluginIntransitive$it" })
+        }
+      )
+
+      withClue("Configuration dokka") {
+        build.output.invariantNewlines() shouldContain /* language=text */ """
+          |--------------------------------------------------
+          |Configuration dokkatoo
+          |--------------------------------------------------
+          |Fetch all Dokkatoo files from all configurations in other subprojects
+          |
+          |Attributes
+          |    - dev.adamko.dokkatoo.base = dokkatoo
+          |
+        """.trimMargin()
+      }
+
+      fun checkConfigurations(format: String) {
+        val formatLowercase = format.toLowerCase()
+
+        allConfigurations shouldContain /* language=text */ """
+          |--------------------------------------------------
+          |Configuration dokkatooParameters$format
+          |--------------------------------------------------
+          |Fetch Dokka Parameters for $formatLowercase from other subprojects
+          |
+          |Attributes
+          |    - dev.adamko.dokkatoo.base     = dokkatoo
+          |    - dev.adamko.dokkatoo.category = generator-parameters
+          |    - dev.adamko.dokkatoo.format   = $formatLowercase
+          |Extended Configurations
+          |    - dokkatoo
+          |
+        """.trimMargin()
+
+
+        allConfigurations shouldContain /* language=text */ """
+          |--------------------------------------------------
+          |Configuration dokkatooGeneratorClasspath$format
+          |--------------------------------------------------
+          |Dokka Generator runtime classpath for $formatLowercase - will be used in Dokka Worker. Should contain all transitive dependencies, plugins (and their transitive dependencies), so Dokka Worker can run.
+          |
+          |Attributes
+          |    - dev.adamko.dokkatoo.base       = dokkatoo
+          |    - dev.adamko.dokkatoo.category   = generator-classpath
+          |    - dev.adamko.dokkatoo.format     = $formatLowercase
+          |    - org.gradle.category            = library
+          |    - org.gradle.dependency.bundling = external
+          |    - org.gradle.jvm.environment     = standard-jvm
+          |    - org.gradle.libraryelements     = jar
+          |    - org.gradle.usage               = java-runtime
+          |Extended Configurations
+          |    - dokkatooPlugin$format
+          |
+       """.trimMargin()
+
+        allConfigurations shouldContain /* language=text */ """
+          |--------------------------------------------------
+          |Configuration dokkatooPlugin$format
+          |--------------------------------------------------
+          |Dokka Plugins classpath for $formatLowercase
+          |
+          |Attributes
+          |    - dev.adamko.dokkatoo.base       = dokkatoo
+          |    - dev.adamko.dokkatoo.category   = plugins-classpath
+          |    - dev.adamko.dokkatoo.format     = $formatLowercase
+          |    - org.gradle.category            = library
+          |    - org.gradle.dependency.bundling = external
+          |    - org.gradle.jvm.environment     = standard-jvm
+          |    - org.gradle.libraryelements     = jar
+          |    - org.gradle.usage               = java-runtime
+          |
+        """.trimMargin()
+
+        allConfigurations shouldContain /* language=text */ """
+          |--------------------------------------------------
+          |Configuration dokkatooPluginIntransitive$format
+          |--------------------------------------------------
+          |Dokka Plugins classpath for $formatLowercase - for internal use. Fetch only the plugins (no transitive dependencies) for use in the Dokka JSON Configuration.
+          |
+          |Attributes
+          |    - dev.adamko.dokkatoo.base       = dokkatoo
+          |    - dev.adamko.dokkatoo.category   = plugins-classpath
+          |    - dev.adamko.dokkatoo.format     = $formatLowercase
+          |    - org.gradle.category            = library
+          |    - org.gradle.dependency.bundling = external
+          |    - org.gradle.jvm.environment     = standard-jvm
+          |    - org.gradle.libraryelements     = jar
+          |    - org.gradle.usage               = java-runtime
+          |Extended Configurations
+          |    - dokkatooPlugin$format
+          |
+        """.trimMargin()
+      }
+
+      expectedFormats.forEach {
+        checkConfigurations(it)
+      }
     }
-
-    fun checkConfigurations(format: String) {
-      val formatCapitalized = format.capitalize()
-
-      build.output.invariantNewlines() shouldContain /* language=text */ """
-        |--------------------------------------------------
-        |Configuration dokkatooParameters$formatCapitalized
-        |--------------------------------------------------
-        |Fetch Dokka Parameters for $format from other subprojects
-        |
-        |Attributes
-        |    - dev.adamko.dokkatoo.base     = dokkatoo
-        |    - dev.adamko.dokkatoo.category = generator-parameters
-        |    - dev.adamko.dokkatoo.format   = $format
-        |Extended Configurations
-        |    - dokkatoo
-        |
-      """.trimMargin()
-
-
-      build.output.invariantNewlines() shouldContain /* language=text */ """
-        |--------------------------------------------------
-        |Configuration dokkatooGeneratorClasspath$formatCapitalized
-        |--------------------------------------------------
-        |Dokka Generator runtime classpath for $format - will be used in Dokka Worker. Should contain all transitive dependencies, plugins (and their transitive dependencies), so Dokka Worker can run.
-        |
-        |Attributes
-        |    - dev.adamko.dokkatoo.base       = dokkatoo
-        |    - dev.adamko.dokkatoo.category   = generator-classpath
-        |    - dev.adamko.dokkatoo.format     = $format
-        |    - org.gradle.category            = library
-        |    - org.gradle.dependency.bundling = external
-        |    - org.gradle.jvm.environment     = standard-jvm
-        |    - org.gradle.libraryelements     = jar
-        |    - org.gradle.usage               = java-runtime
-        |Extended Configurations
-        |    - dokkatooPlugin$formatCapitalized
-        |
-     """.trimMargin()
-
-      build.output.invariantNewlines() shouldContain /* language=text */ """
-        |--------------------------------------------------
-        |Configuration dokkatooPlugin$formatCapitalized
-        |--------------------------------------------------
-        |Dokka Plugins classpath for $format
-        |
-        |Attributes
-        |    - dev.adamko.dokkatoo.base       = dokkatoo
-        |    - dev.adamko.dokkatoo.category   = plugins-classpath
-        |    - dev.adamko.dokkatoo.format     = $format
-        |    - org.gradle.category            = library
-        |    - org.gradle.dependency.bundling = external
-        |    - org.gradle.jvm.environment     = standard-jvm
-        |    - org.gradle.libraryelements     = jar
-        |    - org.gradle.usage               = java-runtime
-        |
-      """.trimMargin()
-
-      build.output.invariantNewlines() shouldContain /* language=text */ """
-        |--------------------------------------------------
-        |Configuration dokkatooPluginIntransitive$formatCapitalized
-        |--------------------------------------------------
-        |Dokka Plugins classpath for $format - for internal use. Fetch only the plugins (no transitive dependencies) for use in the Dokka JSON Configuration.
-        |
-        |Attributes
-        |    - dev.adamko.dokkatoo.base       = dokkatoo
-        |    - dev.adamko.dokkatoo.category   = plugins-classpath
-        |    - dev.adamko.dokkatoo.format     = $format
-        |    - org.gradle.category            = library
-        |    - org.gradle.dependency.bundling = external
-        |    - org.gradle.jvm.environment     = standard-jvm
-        |    - org.gradle.libraryelements     = jar
-        |    - org.gradle.usage               = java-runtime
-        |Extended Configurations
-        |    - dokkatooPlugin$formatCapitalized
-        |
-      """.trimMargin()
-    }
-
-    checkConfigurations("gfm")
-    checkConfigurations("html")
-    checkConfigurations("javadoc")
-    checkConfigurations("jekyll")
   }
 }


### PR DESCRIPTION
Refactor configuration & task names to be specific to each `DokkatooFormatPlugin`


- Breaking change: remove sharing of Dokka plugins between subprojects (it shouldn't be necessary - each generator runs independently per subproject)
- Updated tests