### PR TITLE
Improve test performance

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
@@ -151,14 +151,3 @@ tasks.matching { it.name == "validatePlugins" }.configureEach {
   // Task ':validatePlugins' uses this output of task ':updateTestReportCss' without declaring an explicit or implicit dependency.
   mustRunAfter(updateTestReportCss)
 }
-
-tasks.withType<Test>().configureEach {
-  // Help speed up TestKit tests by re-using dependencies cache (this helps on CI/CD)
-  // https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:shared-readonly-cache
-
-  doFirst("GRADLE_RO_DEP_CACHE on CI - lazy setup workaround for https://github.com/gradle/gradle/issues/24267") {
-    if (providers.environmentVariable("CI").isPresent) {
-      environment("GRADLE_RO_DEP_CACHE", "${gradle.gradleUserHomeDir}/caches")
-    }
-  }
-}

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
@@ -155,5 +155,10 @@ tasks.matching { it.name == "validatePlugins" }.configureEach {
 tasks.withType<Test>().configureEach {
   // Help speed up TestKit tests by re-using dependencies cache (this helps on CI/CD)
   // https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:shared-readonly-cache
-  environment("GRADLE_RO_DEP_CACHE", "${gradle.gradleUserHomeDir}/caches")
+
+  doFirst("GRADLE_RO_DEP_CACHE on CI - lazy setup workaround for https://github.com/gradle/gradle/issues/24267") {
+    if (providers.environmentVariable("CI").isPresent) {
+      environment("GRADLE_RO_DEP_CACHE", "${gradle.gradleUserHomeDir}/caches")
+    }
+  }
 }

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
@@ -151,3 +151,9 @@ tasks.matching { it.name == "validatePlugins" }.configureEach {
   // Task ':validatePlugins' uses this output of task ':updateTestReportCss' without declaring an explicit or implicit dependency.
   mustRunAfter(updateTestReportCss)
 }
+
+tasks.withType<Test>().configureEach {
+  // Help speed up TestKit tests by re-using dependencies cache (this helps on CI/CD)
+  // https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:shared-readonly-cache
+  environment("GRADLE_RO_DEP_CACHE", "${gradle.gradleUserHomeDir}/caches")
+}

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -205,7 +205,7 @@ tasks.withType<Test>().configureEach {
   // this seems to help OOM errors in the Worker Daemons
   //setForkEvery(1)
   jvmArgs(
-    "-Xmx4g",
-    "-XX:MaxMetaspaceSize=1g",
+    "-Xmx1g",
+    "-XX:MaxMetaspaceSize=512g",
   )
 }

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -206,6 +206,6 @@ tasks.withType<Test>().configureEach {
   //setForkEvery(1)
   jvmArgs(
     "-Xmx1g",
-    "-XX:MaxMetaspaceSize=512g",
+    "-XX:MaxMetaspaceSize=512m",
   )
 }

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -201,11 +201,11 @@ tasks.setupDokkaTemplateProjects {
   )
 }
 
-tasks.withType<Test>().configureEach {
-  // this seems to help OOM errors in the Worker Daemons
-  setForkEvery(1)
-  jvmArgs(
-    "-Xmx1g",
-    //"-XX:MaxMetaspaceSize=512m",
-  )
-}
+//tasks.withType<Test>().configureEach {
+//  // this seems to help OOM errors in the Worker Daemons
+//  setForkEvery(1)
+//  jvmArgs(
+//    "-Xmx1g",
+//    //"-XX:MaxMetaspaceSize=512m",
+//  )
+//}

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -201,11 +201,11 @@ tasks.setupDokkaTemplateProjects {
   )
 }
 
-//tasks.withType<Test>().configureEach {
-//  // this seems to help OOM errors in the Worker Daemons
-//  setForkEvery(1)
-//  jvmArgs(
-//    "-Xmx1g",
-//    //"-XX:MaxMetaspaceSize=512m",
-//  )
-//}
+tasks.withType<Test>().configureEach {
+  // this seems to help OOM errors in the Worker Daemons
+  //setForkEvery(1)
+  jvmArgs(
+    "-Xmx4g",
+    "-XX:MaxMetaspaceSize=1g",
+  )
+}

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
@@ -31,6 +31,7 @@ class CustomFormatExampleTest : FunSpec({
           "clean",
           "dokkaCustomFormat",
           "--stacktrace",
+          "--info",
         )
         .forwardOutput()
         .build()
@@ -86,6 +87,7 @@ class CustomFormatExampleTest : FunSpec({
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
+          "--info",
         )
         .forwardOutput()
         .build()
@@ -103,6 +105,7 @@ class CustomFormatExampleTest : FunSpec({
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--build-cache",
+          "--info",
         )
         .forwardOutput()
         .build().should { dokkatooBuildCache ->

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
@@ -39,7 +39,6 @@ class CustomFormatExampleTest : FunSpec({
           "clean",
           "dokkaCustomFormat",
           "--stacktrace",
-          "--info",
         )
         .forwardOutput()
         .build()
@@ -54,7 +53,6 @@ class CustomFormatExampleTest : FunSpec({
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
-          "--info",
         )
         .forwardOutput()
         .build()
@@ -94,7 +92,6 @@ class CustomFormatExampleTest : FunSpec({
         .withArguments(
           "clean",
           ":dokkatooGeneratePublicationHtml",
-          "--info",
           "--stacktrace",
         )
         .forwardOutput()
@@ -112,7 +109,6 @@ class CustomFormatExampleTest : FunSpec({
         .withArguments(
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
-          "--info",
           "--build-cache",
         )
         .forwardOutput()

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
@@ -1,14 +1,6 @@
 package dev.adamko.dokkatoo.tests.examples
 
-import dev.adamko.dokkatoo.utils.GradleProjectTest
-import dev.adamko.dokkatoo.utils.buildGradleKts
-import dev.adamko.dokkatoo.utils.copyExampleProject
-import dev.adamko.dokkatoo.utils.file
-import dev.adamko.dokkatoo.utils.findFiles
-import dev.adamko.dokkatoo.utils.settingsGradleKts
-import dev.adamko.dokkatoo.utils.shouldContainAll
-import dev.adamko.dokkatoo.utils.sideBySide
-import dev.adamko.dokkatoo.utils.toTreeString
+import dev.adamko.dokkatoo.utils.*
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.file.shouldBeAFile
@@ -53,6 +45,7 @@ class CustomFormatExampleTest : FunSpec({
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
+          "--info",
         )
         .forwardOutput()
         .build()

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
@@ -40,6 +40,7 @@ class GradleExampleTest : FunSpec({
           "clean",
           "dokkaHtml",
           "--stacktrace",
+          "--info",
         )
         .forwardOutput()
         .build()
@@ -95,6 +96,7 @@ class GradleExampleTest : FunSpec({
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
+          "--info",
         )
         .forwardOutput()
         .build()
@@ -111,6 +113,7 @@ class GradleExampleTest : FunSpec({
         .withArguments(
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
+          "--info",
           "--build-cache",
         )
         .forwardOutput()

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
@@ -40,7 +40,6 @@ class GradleExampleTest : FunSpec({
           "clean",
           "dokkaHtml",
           "--stacktrace",
-          "--info",
         )
         .forwardOutput()
         .build()
@@ -55,7 +54,6 @@ class GradleExampleTest : FunSpec({
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
-          "--info",
         )
         .forwardOutput()
         .build()
@@ -95,7 +93,6 @@ class GradleExampleTest : FunSpec({
         .withArguments(
           "clean",
           ":dokkatooGeneratePublicationHtml",
-          "--info",
           "--stacktrace",
         )
         .forwardOutput()
@@ -113,7 +110,6 @@ class GradleExampleTest : FunSpec({
         .withArguments(
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
-          "--info",
           "--build-cache",
         )
         .forwardOutput()

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
@@ -54,6 +54,7 @@ class GradleExampleTest : FunSpec({
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
+          "--info",
         )
         .forwardOutput()
         .build()

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
@@ -57,6 +57,7 @@ class MultimoduleExampleTest : FunSpec({
           "clean",
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--stacktrace",
+          "--info",
         )
         .forwardOutput()
         .build()

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
@@ -1,18 +1,7 @@
 package dev.adamko.dokkatoo.tests.examples
 
-import dev.adamko.dokkatoo.utils.GradleProjectTest
+import dev.adamko.dokkatoo.utils.*
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
-import dev.adamko.dokkatoo.utils.buildGradleKts
-import dev.adamko.dokkatoo.utils.copyExampleProject
-import dev.adamko.dokkatoo.utils.dir
-import dev.adamko.dokkatoo.utils.file
-import dev.adamko.dokkatoo.utils.findFiles
-import dev.adamko.dokkatoo.utils.invariantNewlines
-import dev.adamko.dokkatoo.utils.settingsGradleKts
-import dev.adamko.dokkatoo.utils.shouldContainAll
-import dev.adamko.dokkatoo.utils.shouldNotContainAnyOf
-import dev.adamko.dokkatoo.utils.sideBySide
-import dev.adamko.dokkatoo.utils.toTreeString
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.file.shouldBeAFile
@@ -43,6 +32,7 @@ class MultimoduleExampleTest : FunSpec({
           "clean",
           "dokkaHtmlMultiModule",
           "--stacktrace",
+          "--info",
         )
         .forwardOutput()
         .build()
@@ -135,6 +125,7 @@ class MultimoduleExampleTest : FunSpec({
           .withArguments(
             ":parentProject:dokkatooGeneratePublicationHtml",
             "--stacktrace",
+            "--info",
             "--build-cache",
           )
           .forwardOutput()

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
@@ -43,7 +43,6 @@ class MultimoduleExampleTest : FunSpec({
           "clean",
           "dokkaHtmlMultiModule",
           "--stacktrace",
-          "--info",
         )
         .forwardOutput()
         .build()
@@ -58,7 +57,6 @@ class MultimoduleExampleTest : FunSpec({
           "clean",
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--stacktrace",
-          "--info",
         )
         .forwardOutput()
         .build()
@@ -108,7 +106,6 @@ class MultimoduleExampleTest : FunSpec({
         .withArguments(
           "clean",
           ":parentProject:dokkatooGeneratePublicationHtml",
-          "--info",
           "--stacktrace",
         )
         .forwardOutput()
@@ -137,7 +134,6 @@ class MultimoduleExampleTest : FunSpec({
           .withArguments(
             ":parentProject:dokkatooGeneratePublicationHtml",
             "--stacktrace",
-            "--info",
             "--build-cache",
           )
           .forwardOutput()

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -34,9 +34,6 @@ class BasicProjectIntegrationTest : FunSpec({
         "--stacktrace",
       )
       .forwardOutput()
-      .withEnvironment {
-        set("DOKKA_VERSION", "1.7.20")
-      }
       .build()
 
     val dokkatooBuild = dokkatooProject.runner
@@ -168,6 +165,7 @@ private fun initDokkaProject(
         """../template.root.gradle.kts""",
         """./template.root.gradle.kts""",
       )
+      .replace("""${'$'}{System.getenv("DOKKA_VERSION")}""", "1.7.20")
 
     // update relative paths to the template files - they're now in the same directory
     settingsGradleKts = settingsGradleKts

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -1,19 +1,7 @@
 package dev.adamko.dokkatoo.tests.integration
 
-import dev.adamko.dokkatoo.utils.GradleProjectTest
+import dev.adamko.dokkatoo.utils.*
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
-import dev.adamko.dokkatoo.utils.NotWindowsCondition
-import dev.adamko.dokkatoo.utils.buildGradleKts
-import dev.adamko.dokkatoo.utils.copyIntegrationTestProject
-import dev.adamko.dokkatoo.utils.file
-import dev.adamko.dokkatoo.utils.findFiles
-import dev.adamko.dokkatoo.utils.projectFile
-import dev.adamko.dokkatoo.utils.settingsGradleKts
-import dev.adamko.dokkatoo.utils.shouldContainAll
-import dev.adamko.dokkatoo.utils.shouldNotContainAnyOf
-import dev.adamko.dokkatoo.utils.sideBySide
-import dev.adamko.dokkatoo.utils.toTreeString
-import dev.adamko.dokkatoo.utils.withEnvironment
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.file.shouldBeAFile
@@ -44,7 +32,6 @@ class BasicProjectIntegrationTest : FunSpec({
         "clean",
         "dokkaHtml",
         "--stacktrace",
-        "--info",
       )
       .forwardOutput()
       .withEnvironment(
@@ -57,7 +44,6 @@ class BasicProjectIntegrationTest : FunSpec({
         "clean",
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",
-        "--info",
       )
       .forwardOutput()
       .build()
@@ -121,7 +107,6 @@ class BasicProjectIntegrationTest : FunSpec({
         .withArguments(
           "dokkatooGeneratePublicationHtml",
           "--stacktrace",
-          "--info",
           "--build-cache",
         )
         .forwardOutput()

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -34,9 +34,9 @@ class BasicProjectIntegrationTest : FunSpec({
         "--stacktrace",
       )
       .forwardOutput()
-      .addEnvironment(
-        "DOKKA_VERSION" to "1.7.20",
-      )
+      .withEnvironment {
+        set("DOKKA_VERSION", "1.7.20")
+      }
       .build()
 
     val dokkatooBuild = dokkatooProject.runner

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -34,7 +34,7 @@ class BasicProjectIntegrationTest : FunSpec({
         "--stacktrace",
       )
       .forwardOutput()
-      .withEnvironment(
+      .addEnvironment(
         "DOKKA_VERSION" to "1.7.20",
       )
       .build()

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -74,7 +74,7 @@ constructor(
       workerLogFile.set(temporaryDir.resolve("dokka-worker.log"))
       // increase memory - DokkaGenerator is hungry https://github.com/Kotlin/dokka/issues/1405
       workerMinHeapSize.convention("512m")
-      workerMaxHeapSize.convention("2g")
+      workerMaxHeapSize.convention("1g")
       workerJvmArgs.set(
         listOf(
           //"-XX:MaxMetaspaceSize=512m",

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -83,7 +83,7 @@ fun gradleKtsProjectTest(
     settingsGradleKts = """
       |rootProject.name = "test"
       |
-      |@Suppress("UnstableApiUsage") // Central declaration of repositories is an incubating feature
+      |@Suppress("UnstableApiUsage")
       |dependencyResolutionManagement {
       |    repositories {
       |        mavenCentral()

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -24,7 +24,7 @@ class GradleProjectTest(
 
   val runner: GradleRunner = GradleRunner.create()
     .withProjectDir(projectDir.toFile())
-    .withJvmArguments("-XX:MaxMetaspaceSize=1g")
+    .withJvmArguments("-XX:MaxMetaspaceSize=512m")
     .withEnvironment {
       GRADLE_RO_DEP_CACHE?.let { put("GRADLE_RO_DEP_CACHE", it) }
     }

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -25,7 +25,9 @@ class GradleProjectTest(
   val runner: GradleRunner = GradleRunner.create()
     .withProjectDir(projectDir.toFile())
     .withJvmArguments("-XX:MaxMetaspaceSize=1g")
-    .addEnvironment("GRADLE_RO_DEP_CACHE" to GRADLE_RO_DEP_CACHE)
+    .withEnvironment {
+      GRADLE_RO_DEP_CACHE?.let { put("GRADLE_RO_DEP_CACHE", it) }
+    }
 
   val testMavenRepoRelativePath: String =
     projectDir.relativize(testMavenRepoDir).toFile().invariantSeparatorsPath

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -4,7 +4,6 @@ import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.properties.PropertyDelegateProvider
-import kotlin.properties.ReadOnlyProperty
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 import org.gradle.testkit.runner.GradleRunner
@@ -26,10 +25,10 @@ class GradleProjectTest(
   val runner: GradleRunner = GradleRunner.create()
     .withProjectDir(projectDir.toFile())
     .withJvmArguments("-XX:MaxMetaspaceSize=1g")
+    .addEnvironment("GRADLE_RO_DEP_CACHE" to GRADLE_RO_DEP_CACHE)
 
   val testMavenRepoRelativePath: String =
     projectDir.relativize(testMavenRepoDir).toFile().invariantSeparatorsPath
-
 
   companion object {
 
@@ -43,20 +42,12 @@ class GradleProjectTest(
       projectTestTempDir.resolve("functional-tests")
     }
 
-    private val dokkaSourceDir: Path by systemProperty(Paths::get)
     /** Dokka Source directory that contains Gradle projects used for integration tests */
     val integrationTestProjectsDir: Path by systemProperty(Paths::get)
     /** Dokka Source directory that contains example Gradle projects */
     val exampleProjectsDir: Path by systemProperty(Paths::get)
 
-    private fun <T> systemProperty(
-      convert: (String) -> T,
-    ) = ReadOnlyProperty<Any, T> { _, property ->
-      val value = requireNotNull(System.getProperty(property.name)) {
-        "system property ${property.name} is unavailable"
-      }
-      convert(value)
-    }
+    val GRADLE_RO_DEP_CACHE: String? by optionalEnvironmentVariable()
   }
 }
 

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -25,9 +25,6 @@ class GradleProjectTest(
   val runner: GradleRunner = GradleRunner.create()
     .withProjectDir(projectDir.toFile())
     .withJvmArguments("-XX:MaxMetaspaceSize=512m")
-    .withEnvironment {
-      GRADLE_RO_DEP_CACHE?.let { put("GRADLE_RO_DEP_CACHE", it) }
-    }
 
   val testMavenRepoRelativePath: String =
     projectDir.relativize(testMavenRepoDir).toFile().invariantSeparatorsPath

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -23,7 +23,9 @@ class GradleProjectTest(
     baseDir: Path = funcTestTempDir,
   ) : this(projectDir = baseDir.resolve(testProjectName))
 
-  val runner: GradleRunner = GradleRunner.create().withProjectDir(projectDir.toFile())
+  val runner: GradleRunner = GradleRunner.create()
+    .withProjectDir(projectDir.toFile())
+    .withJvmArguments("-XX:MaxMetaspaceSize=1g")
 
   val testMavenRepoRelativePath: String =
     projectDir.relativize(testMavenRepoDir).toFile().invariantSeparatorsPath

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
@@ -4,12 +4,15 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.DefaultGradleRunner
 
-fun GradleRunner.withEnvironment(vararg map: Pair<String, String>): GradleRunner =
-  withEnvironment(map.toMap())
+/** Append environment variables to the existing environment variables set in the runner. */
+fun GradleRunner.addEnvironment(vararg map: Pair<String, String?>): GradleRunner =
+  withEnvironment((environment ?: emptyMap()) + map.toMap())
+
 
 inline fun GradleRunner.build(
   handleResult: BuildResult.() -> Unit
 ): Unit = build().let(handleResult)
+
 
 inline fun GradleRunner.buildAndFail(
   handleResult: BuildResult.() -> Unit

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
@@ -6,6 +6,7 @@ import org.gradle.testkit.runner.internal.DefaultGradleRunner
 
 
 /** Edit environment variables in the Gradle Runner */
+@Deprecated("Windows does not support withEnvironment - https://github.com/gradle/gradle/issues/23959")
 fun GradleRunner.withEnvironment(build: MutableMap<String, String?>.() -> Unit): GradleRunner {
   val env = environment ?: mutableMapOf()
   env.build()

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
@@ -2,6 +2,7 @@ package dev.adamko.dokkatoo.utils
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.internal.DefaultGradleRunner
 
 fun GradleRunner.withEnvironment(vararg map: Pair<String, String>): GradleRunner =
   withEnvironment(map.toMap())
@@ -11,5 +12,10 @@ inline fun GradleRunner.build(
 ): Unit = build().let(handleResult)
 
 inline fun GradleRunner.buildAndFail(
-  handleResult: BuildResult.( ) -> Unit
+  handleResult: BuildResult.() -> Unit
 ): Unit = buildAndFail().let(handleResult)
+
+
+fun GradleRunner.withJvmArguments(
+  vararg jvmArguments: String
+): GradleRunner = (this as DefaultGradleRunner).withJvmArguments(*jvmArguments)

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
@@ -4,9 +4,13 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.DefaultGradleRunner
 
-/** Append environment variables to the existing environment variables set in the runner. */
-fun GradleRunner.addEnvironment(vararg map: Pair<String, String?>): GradleRunner =
-  withEnvironment((environment ?: emptyMap()) + map.toMap())
+
+/** Edit environment variables in the Gradle Runner */
+fun GradleRunner.withEnvironment(build: MutableMap<String, String?>.() -> Unit): GradleRunner {
+  val env = environment ?: mutableMapOf()
+  env.build()
+  return withEnvironment(env)
+}
 
 
 inline fun GradleRunner.build(

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/systemVariableProviders.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/systemVariableProviders.kt
@@ -1,0 +1,40 @@
+package dev.adamko.dokkatoo.utils
+
+import kotlin.properties.ReadOnlyProperty
+
+// Utilities for fetching System Properties and Environment Variables via delegated properties
+
+
+internal fun optionalSystemProperty() = optionalSystemProperty { it }
+
+internal fun <T : Any> optionalSystemProperty(
+  convert: (String) -> T?
+): ReadOnlyProperty<Any, T?> =
+  ReadOnlyProperty { _, property ->
+    val value = System.getProperty(property.name)
+    if (value != null) convert(value) else null
+  }
+
+
+internal fun systemProperty() = systemProperty { it }
+
+internal fun <T> systemProperty(
+  convert: (String) -> T
+): ReadOnlyProperty<Any, T> =
+  ReadOnlyProperty { _, property ->
+    val value = requireNotNull(System.getProperty(property.name)) {
+      "system property ${property.name} is unavailable"
+    }
+    convert(value)
+  }
+
+
+internal fun optionalEnvironmentVariable() = optionalEnvironmentVariable { it }
+
+internal fun <T : Any> optionalEnvironmentVariable(
+  convert: (String) -> T?
+): ReadOnlyProperty<Any, T?> =
+  ReadOnlyProperty { _, property ->
+    val value = System.getenv(property.name)
+    if (value != null) convert(value) else null
+  }

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -28,7 +28,6 @@ class MultiModuleFunctionalTest : FunSpec({
         "clean",
         ":dokkatooGenerate",
         "--stacktrace",
-        "--info",
       )
       .forwardOutput()
       .build {
@@ -144,7 +143,6 @@ class MultiModuleFunctionalTest : FunSpec({
           //"clean",
           ":dokkatooGenerate",
           "--stacktrace",
-          "--info",
           "--build-cache",
         )
         .forwardOutput()
@@ -170,7 +168,6 @@ class MultiModuleFunctionalTest : FunSpec({
           .withArguments(
             ":dokkatooGenerate",
             "--stacktrace",
-            "--info",
             "--build-cache",
           )
           .forwardOutput()
@@ -207,7 +204,6 @@ class MultiModuleFunctionalTest : FunSpec({
           //"clean",
           ":dokkatooGenerate",
           "--stacktrace",
-          "--info",
           "--no-build-cache",
           "--configuration-cache",
         )
@@ -247,7 +243,6 @@ class MultiModuleFunctionalTest : FunSpec({
             //"clean",
             ":dokkatooGeneratePublicationHtml",
             "--stacktrace",
-            "--info",
             "--build-cache",
           )
           .forwardOutput()
@@ -279,7 +274,6 @@ class MultiModuleFunctionalTest : FunSpec({
             .withArguments(
               ":dokkatooGeneratePublicationHtml",
               "--stacktrace",
-              "--info",
               "--build-cache",
             )
             .forwardOutput()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
   }
 }
 
-@Suppress("UnstableApiUsage") // Central declaration of repositories is an incubating feature
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
 
   repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)


### PR DESCRIPTION
* remove `--info` from tests - Gradle TestKit can't handle the amount of logging and it runs out of memory
* Increase TestKit memory https://github.com/gradle/gradle/issues/10527#issuecomment-1249235708
* ~~Set up [`GRADLE_RO_DEP_CACHE`](https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:shared-readonly-cache)~~ not possible, `withEnvironment()` doesn't work on Windows so I can't pass the environment variable to the TestKit runner. On the plus side, there's a workaround for #10.