### PR TITLE
Simplify release versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Dokkatoo has a number of improvements over the existing Dokka Gradle Plugin:
 Dokkatoo has basic functionality, and can generate documentation for single-projects and
 multimodule projects.
 
-Be aware that many of things are untested, broken, and undocumented. Please
+Be aware that many things are untested, broken, and undocumented. Please
 [create an issue](https://github.com/adamko-dev/dokkatoo/issues)
 if something is not as you'd expect, or like.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
   buildsrc.conventions.base
 
   idea
-
-  //id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.12.1"
 }
 
 group = "dev.adamko.dokkatoo"

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/dokkatoo-example-projects.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/dokkatoo-example-projects.gradle.kts
@@ -10,10 +10,13 @@ plugins {
   id("buildsrc.conventions.dokkatoo-example-projects-base")
 }
 
+val TASK_GROUP = "dokkatoo examples"
 
 val prepareDokkaSourceTask = tasks.named<Sync>("prepareDokkaSource")
 
 val setupDokkaTemplateProjects by tasks.registering(SetupDokkaProjects::class) {
+  group = TASK_GROUP
+
   dependsOn(prepareDokkaSourceTask)
   destinationToSources.convention(emptyMap())
   dokkaSourceDir.set(
@@ -25,8 +28,9 @@ val setupDokkaTemplateProjects by tasks.registering(SetupDokkaProjects::class) {
 
 val mavenPublishTestExtension = extensions.getByType<MavenPublishTest>()
 
-val updateGradlePropertiesInDokkatooExamples by tasks.registering {
-  group = "dokkatoo examples"
+
+val updateDokkatooExamplesGradleProperties by tasks.registering {
+  group = TASK_GROUP
 
   mustRunAfter(tasks.withType<SetupDokkaProjects>())
 
@@ -64,7 +68,60 @@ val updateGradlePropertiesInDokkatooExamples by tasks.registering {
   }
 }
 
+val dokkatooVersion = provider { project.version.toString() }
+
+val updateDokkatooExamplesBuildFiles by tasks.registering {
+  group = TASK_GROUP
+  description = "Update the Gradle build files in the Dokkatoo examples"
+
+  outputs.upToDateWhen { false }
+
+  mustRunAfter(tasks.withType<SetupDokkaProjects>())
+  shouldRunAfter(updateDokkatooExamplesGradleProperties)
+
+  val dokkatooVersion = dokkatooVersion
+
+  val dokkatooPluginVersionMatcher = """
+    id[^"]+?\"dev\.adamko\.dokkatoo\".+?version \"([^"]+?)\"
+    """.trimIndent().toRegex()
+
+  val gradleBuildFiles =
+    layout.projectDirectory.asFileTree
+      .matching {
+        include(
+          "**/*dokkatoo*/build.gradle.kts",
+          "**/*dokkatoo*/build.gradle",
+        )
+      }.filter {
+        dokkatooPluginVersionMatcher.containsMatchIn(it.readText())
+      }.elements
+
+  outputs.files(gradleBuildFiles)
+
+  doLast {
+    gradleBuildFiles.get().forEach {
+      val file = it.asFile
+
+      file.writeText(
+        file.readText().replace(dokkatooPluginVersionMatcher) {
+          val oldVersion = it.groupValues[1]
+          it.value.replace(oldVersion, dokkatooVersion.get())
+        })
+    }
+  }
+}
+
+
+val updateDokkatooExamples by tasks.registering task@{
+  group = TASK_GROUP
+  description = "lifecycle task for all '$TASK_GROUP' tasks"
+  dependsOn(
+    setupDokkaTemplateProjects,
+    updateDokkatooExamplesGradleProperties,
+    updateDokkatooExamplesBuildFiles,
+  )
+}
+
 tasks.assemble {
-  dependsOn(setupDokkaTemplateProjects)
-  dependsOn(updateGradlePropertiesInDokkatooExamples)
+  dependsOn(updateDokkatooExamples)
 }

--- a/buildSrc/src/main/kotlin/buildsrc/tasks/SetupDokkaProjects.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/tasks/SetupDokkaProjects.kt
@@ -40,7 +40,7 @@ abstract class SetupDokkaProjects @Inject constructor(
     val destinationToSources = destinationToSources.get()
     val dokkaSourceDir = dokkaSourceDir.get()
 
-    println("destinationToSources: $destinationToSources")
+    logger.info("destinationToSources: $destinationToSources")
 
     destinationToSources.forEach { (dest: File, sources: List<String>) ->
       fs.sync {

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
   buildsrc.conventions.`dokkatoo-example-projects`
 }
 
-
-dependencies {
-//  testMavenPublication(projects.modules.dokkatooPlugin)
-}
-
 tasks.setupDokkaTemplateProjects {
   destinationToSources.set(
     mapOf(
@@ -27,26 +22,8 @@ tasks.setupDokkaTemplateProjects {
 configurations.exampleProjectsElements.configure {
   outgoing {
     artifact(projectDir) {
-      builtBy(tasks.setupDokkaTemplateProjects, tasks.updateGradlePropertiesInDokkatooExamples)
+      builtBy(tasks.updateDokkatooExamples)
       type = "directory"
     }
   }
-//  outgoing {
-//    listOf(
-//      "custom-format-example",
-//      "gradle-example",
-//      "kotlin-as-java-example",
-//      "library-publishing-example",
-//      "multimodule-example",
-//      "multiplatform-example",
-//      "versioning-multimodule-example",
-//    ).forEach { exampleDir ->
-//      artifact(layout.projectDirectory.dir("$exampleDir/dokka")) {
-//        builtBy(tasks.setupDokkaTemplateProjects)
-//      }
-//      artifact(layout.projectDirectory.dir("$exampleDir/dokkatoo")) {
-//        builtBy(tasks.setupDokkaTemplateProjects, tasks.updateGradlePropertiesInDokkatooExamples)
-//      }
-//    }
-//  }
 }

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -85,8 +85,7 @@ testing.suites {
 
         // depend on example & integration-test projects setup
         dependsOn(configurations.exampleProjects)
-        dependsOn(tasks.setupDokkaTemplateProjects)
-        dependsOn(tasks.updateGradlePropertiesInDokkatooExamples)
+        dependsOn(tasks.updateDokkatooExamples)
 
         val dokkatooExamplesDir = configurations.exampleProjects.map {
           it.incoming.artifactView { lenient(true) }.files.singleFile.absolutePath

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -115,7 +115,7 @@ constructor(
       dokkatooConfigurationsDirectory.convention(layout.buildDirectory.dir("dokka-config"))
 
       extensions.create<DokkatooExtension.Versions>("versions").apply {
-        jetbrainsDokka.convention("1.7.20")
+        jetbrainsDokka.convention(DokkatooConstants.DOKKA_VERSION)
         jetbrainsMarkdown.convention("0.3.1")
         freemarker.convention("2.3.31")
         kotlinxHtml.convention("0.8.0")

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
@@ -1,10 +1,7 @@
 package dev.adamko.dokkatoo
 
-import dev.adamko.dokkatoo.utils.buildGradleKts
-import dev.adamko.dokkatoo.utils.gradleKtsProjectTest
-import dev.adamko.dokkatoo.utils.invariantNewlines
-import dev.adamko.dokkatoo.utils.shouldContainExactly
-import dev.adamko.dokkatoo.utils.splitToPair
+import dev.adamko.dokkatoo.internal.DokkatooConstants.DOKKATOO_VERSION
+import dev.adamko.dokkatoo.utils.*
 import io.kotest.assertions.asClue
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -15,7 +12,7 @@ class DokkatooPluginFunctionalTest {
   private val testProject = gradleKtsProjectTest("DokkatooPluginFunctionalTest") {
     buildGradleKts = """
       |plugins {
-      |    id("dev.adamko.dokkatoo") version "0.0.4-SNAPSHOT"
+      |    id("dev.adamko.dokkatoo") version "$DOKKATOO_VERSION"
       |}
       |
     """.trimMargin()

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -1,6 +1,7 @@
 package dev.adamko.dokkatoo
 
 import dev.adamko.dokkatoo.dokka.parameters.DokkaParametersKxs
+import dev.adamko.dokkatoo.internal.DokkatooConstants.DOKKATOO_VERSION
 import dev.adamko.dokkatoo.utils.*
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
@@ -368,7 +369,7 @@ private fun initDokkatooProject(
       |  // Kotlin plugin shouldn't be necessary here, but without it Dokka errors
       |  // with ClassNotFound KotlinPluginExtension... very weird
       |  kotlin("jvm") version "1.7.20" apply false
-      |  id("dev.adamko.dokkatoo") version "0.0.4-SNAPSHOT"
+      |  id("dev.adamko.dokkatoo") version "$DOKKATOO_VERSION"
       |}
       |
       |dependencies {
@@ -383,7 +384,7 @@ private fun initDokkatooProject(
       buildGradleKts = """
           |plugins {
           |    kotlin("jvm") version "1.7.20"
-          |    id("dev.adamko.dokkatoo") version "0.0.4-SNAPSHOT"
+          |    id("dev.adamko.dokkatoo") version "$DOKKATOO_VERSION"
           |}
           |
         """.trimMargin()
@@ -410,7 +411,7 @@ private fun initDokkatooProject(
       buildGradleKts = """
           |plugins {
           |    kotlin("jvm") version "1.7.20"
-          |    id("dev.adamko.dokkatoo") version "0.0.4-SNAPSHOT"
+          |    id("dev.adamko.dokkatoo") version "$DOKKATOO_VERSION"
           |}
           |
         """.trimMargin()


### PR DESCRIPTION
Automate the Dokkatoo version based on the root project version.

Additionally, re-use the Dokka version in the build config and plugin config