### PR TITLE
remove Dokka code from public API, replace with equivalents

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ dokkatoo {
   dokkatooSourceSets.configureEach {
     documentedVisibilities(
       VisibilityModifier.PUBLIC,
-       VisibilityModifier.PROTECTED,
+      VisibilityModifier.PROTECTED,
     )
     suppressedFiles.from(file("src/main/kotlin/it/suppressedByPath"))
     perPackageOption {

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ dokkatoo {
   dokkatooPublications.configureEach {
     suppressObviousFunctions.set(true)
     pluginsConfiguration.create("org.jetbrains.dokka.base.DokkaBase") {
-      serializationFormat.set(DokkaConfiguration.SerializationFormat.JSON)
+      serializationFormat.set(DokkaPluginConfigurationSpec.EncodedFormat.JSON)
       values.set(
         """
           { 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ dokkatoo {
   moduleName.set("Basic Project")
   dokkatooSourceSets.configureEach {
     documentedVisibilities(
-      DokkaConfiguration.Visibility.PUBLIC,
-      DokkaConfiguration.Visibility.PROTECTED,
+      VisibilityModifier.PUBLIC,
+       VisibilityModifier.PROTECTED,
     )
     suppressedFiles.from(file("src/main/kotlin/it/suppressedByPath"))
     perPackageOption {

--- a/examples/custom-format-example/dokkatoo/build.gradle.kts
+++ b/examples/custom-format-example/dokkatoo/build.gradle.kts
@@ -8,7 +8,6 @@ dokkatoo {
   dokkatooPublications.named("html") {
 //  dokkatooPublications.configureEach {
     pluginsConfiguration.create("org.jetbrains.dokka.base.DokkaBase") {
-      serializationFormat.set(org.jetbrains.dokka.DokkaConfiguration.SerializationFormat.JSON)
       /** Custom format adds a custom logo */
       values.set(
         """

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.dokka.DokkaConfiguration
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
 
 plugins {
   kotlin("jvm") version "1.7.20"

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.dokka.DokkaConfiguration
 import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
 
 plugins {
@@ -43,7 +42,6 @@ dokkatoo {
   dokkatooPublications.configureEach {
     suppressObviousFunctions.set(true)
     pluginsConfiguration.create("org.jetbrains.dokka.base.DokkaBase") {
-      serializationFormat.set(DokkaConfiguration.SerializationFormat.JSON)
       values.set(
         """
           { 

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
@@ -16,8 +16,8 @@ dokkatoo {
   moduleName.set("Basic Project")
   dokkatooSourceSets.configureEach {
     documentedVisibilities(
-      DokkaConfiguration.Visibility.PUBLIC,
-      DokkaConfiguration.Visibility.PROTECTED,
+      VisibilityModifier.PUBLIC,
+      VisibilityModifier.PROTECTED,
     )
     suppressedFiles.from(file("src/main/kotlin/it/suppressedByPath"))
     perPackageOption {
@@ -26,8 +26,8 @@ dokkatoo {
     }
     perPackageOption {
       matchingRegex.set("it.overriddenVisibility.*")
-      documentedVisibilities.set(
-        setOf(DokkaConfiguration.Visibility.PRIVATE)
+      documentedVisibilities(
+        VisibilityModifier.PRIVATE,
       )
     }
     sourceLink {

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -96,6 +96,13 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurat
 	public abstract fun getValues ()Lorg/gradle/api/provider/Property;
 }
 
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurationSpec$EncodedFormat : java/lang/Enum {
+	public static final field JSON Ldev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurationSpec$EncodedFormat;
+	public static final field XML Ldev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurationSpec$EncodedFormat;
+	public static fun valueOf (Ljava/lang/String;)Ldev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurationSpec$EncodedFormat;
+	public static fun values ()[Ldev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurationSpec$EncodedFormat;
+}
+
 public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceLinkSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable {
 	public synthetic fun build ()Ljava/lang/Object;
 	public abstract fun getLocalDirectory ()Lorg/gradle/api/file/DirectoryProperty;

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -68,7 +68,7 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaExternalDocument
 	public final fun url (Lorg/gradle/api/provider/Provider;)V
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaPackageOptionsSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaPackageOptionsSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, dev/adamko/dokkatoo/dokka/parameters/HasConfigurableVisibilityModifiers, java/io/Serializable {
 	public synthetic fun build ()Ljava/lang/Object;
 	public abstract fun getDocumentedVisibilities ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getMatchingRegex ()Lorg/gradle/api/provider/Property;
@@ -114,9 +114,8 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIDSpec 
 	public abstract fun setSourceSetName (Ljava/lang/String;)V
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable, org/gradle/api/Named {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, dev/adamko/dokkatoo/dokka/parameters/HasConfigurableVisibilityModifiers, java/io/Serializable, org/gradle/api/Named {
 	public synthetic fun build ()Ljava/lang/Object;
-	public final fun documentedVisibilities ([Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;)V
 	public final fun externalDocumentationLink (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun externalDocumentationLink (Ljava/net/URL;Ljava/net/URL;)V
 	public final fun externalDocumentationLink (Lorg/gradle/api/Action;)V

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -51,12 +51,13 @@ public abstract class dev/adamko/dokkatoo/dokka/DokkaPublication : java/io/Seria
 	public abstract fun getOfflineMode ()Lorg/gradle/api/provider/Property;
 	public abstract fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
 	protected final fun getOutputDirPath ()Lorg/gradle/api/provider/Provider;
-	public abstract fun getPluginsConfiguration ()Lorg/gradle/api/NamedDomainObjectContainer;
+	public final fun getPluginsConfiguration ()Lorg/gradle/api/ExtensiblePolymorphicDomainObjectContainer;
 	public abstract fun getSuppressInheritedMembers ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSuppressObviousFunctions ()Lorg/gradle/api/provider/Property;
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaExternalDocumentationLinkSpec : java/io/Serializable, org/gradle/api/Named {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaExternalDocumentationLinkSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable, org/gradle/api/Named {
+	public synthetic fun build ()Ljava/lang/Object;
 	public abstract fun getEnabled ()Lorg/gradle/api/provider/Property;
 	public fun getName ()Ljava/lang/String;
 	public abstract fun getPackageListUrl ()Lorg/gradle/api/provider/Property;
@@ -67,7 +68,7 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaExternalDocument
 	public final fun url (Lorg/gradle/api/provider/Provider;)V
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaPackageOptionsSpec : java/io/Serializable, org/jetbrains/dokka/DokkaConfigurationBuilder {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaPackageOptionsSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable {
 	public synthetic fun build ()Ljava/lang/Object;
 	public abstract fun getDocumentedVisibilities ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getMatchingRegex ()Lorg/gradle/api/provider/Property;
@@ -87,7 +88,7 @@ public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$$seri
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurationSpec : java/io/Serializable, org/gradle/api/Named, org/jetbrains/dokka/DokkaConfigurationBuilder {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurationSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable, org/gradle/api/Named {
 	public synthetic fun build ()Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public final fun getPluginFqn ()Ljava/lang/String;
@@ -95,7 +96,7 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaPluginConfigurat
 	public abstract fun getValues ()Lorg/gradle/api/provider/Property;
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceLinkSpec : java/io/Serializable, org/jetbrains/dokka/DokkaConfigurationBuilder {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceLinkSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable {
 	public synthetic fun build ()Ljava/lang/Object;
 	public abstract fun getLocalDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	protected final fun getLocalDirectoryPath ()Lorg/gradle/api/provider/Provider;
@@ -105,7 +106,7 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceLinkSpec :
 	public final fun remoteUrl (Lorg/gradle/api/provider/Provider;)V
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIDSpec : org/gradle/api/Named, org/jetbrains/dokka/DokkaConfigurationBuilder {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIDSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, org/gradle/api/Named {
 	public synthetic fun build ()Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public final fun getScopeId ()Ljava/lang/String;
@@ -113,9 +114,9 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIDSpec 
 	public abstract fun setSourceSetName (Ljava/lang/String;)V
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : java/io/Serializable, org/gradle/api/Named, org/jetbrains/dokka/DokkaConfigurationBuilder {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable, org/gradle/api/Named {
 	public synthetic fun build ()Ljava/lang/Object;
-	public final fun documentedVisibilities ([Lorg/jetbrains/dokka/DokkaConfiguration$Visibility;)V
+	public final fun documentedVisibilities ([Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;)V
 	public final fun externalDocumentationLink (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun externalDocumentationLink (Ljava/net/URL;Ljava/net/URL;)V
 	public final fun externalDocumentationLink (Lorg/gradle/api/Action;)V
@@ -149,6 +150,20 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : 
 	public abstract fun getSuppressedFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun perPackageOption (Lorg/gradle/api/Action;)V
 	public final fun sourceLink (Lorg/gradle/api/Action;)V
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/VisibilityModifier : java/lang/Enum {
+	public static final field Companion Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier$Companion;
+	public static final field INTERNAL Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;
+	public static final field PACKAGE Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;
+	public static final field PRIVATE Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;
+	public static final field PROTECTED Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;
+	public static final field PUBLIC Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;
+	public static fun valueOf (Ljava/lang/String;)Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;
+	public static fun values ()[Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/VisibilityModifier$Companion {
 }
 
 public abstract class dev/adamko/dokkatoo/formats/DokkatooFormatPlugin : org/gradle/api/Plugin {

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -51,7 +51,7 @@ public abstract class dev/adamko/dokkatoo/dokka/DokkaPublication : java/io/Seria
 	public abstract fun getOfflineMode ()Lorg/gradle/api/provider/Property;
 	public abstract fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
 	protected final fun getOutputDirPath ()Lorg/gradle/api/provider/Provider;
-	public final fun getPluginsConfiguration ()Lorg/gradle/api/ExtensiblePolymorphicDomainObjectContainer;
+	public abstract fun getPluginsConfiguration ()Lorg/gradle/api/NamedDomainObjectContainer;
 	public abstract fun getSuppressInheritedMembers ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSuppressObviousFunctions ()Lorg/gradle/api/provider/Property;
 }

--- a/modules/dokkatoo-plugin/build.gradle.kts
+++ b/modules/dokkatoo-plugin/build.gradle.kts
@@ -261,8 +261,3 @@ dokkatoo {
     })
   }
 }
-
-tasks.withType<BCVDefaultTask>().configureEach {
-  // run unit tests first, because I care about them more, and it's annoying to get interrupted by BCV
-  shouldRunAfter(tasks.withType<Test>())
-}

--- a/modules/dokkatoo-plugin/build.gradle.kts
+++ b/modules/dokkatoo-plugin/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("UnstableApiUsage") // jvm test suites & test report aggregation are incubating
 
 import buildsrc.conventions.utils.skipTestFixturesPublications
+import dev.adamko.kotlin.binary_compatibility_validator.tasks.BCVDefaultTask
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -259,4 +260,9 @@ dokkatoo {
       include("**/DokkatooInternalApi.kt")
     })
   }
+}
+
+tasks.withType<BCVDefaultTask>().configureEach {
+  // run unit tests first, because I care about them more, and it's annoying to get interrupted by BCV
+  shouldRunAfter(tasks.withType<Test>())
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -271,7 +271,7 @@ constructor(
     protected fun String.appendFormat(): String =
       when (val name = formatName) {
         null -> this
-        else -> this + name.capitalize()
+        else -> this + name.uppercaseFirstChar()
       }
   }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -4,6 +4,7 @@ import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_BASE_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_CATEGORY_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKA_FORMAT_ATTRIBUTE
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
 import dev.adamko.dokkatoo.formats.*
 import dev.adamko.dokkatoo.internal.*
 import dev.adamko.dokkatoo.tasks.DokkatooGenerateTask
@@ -163,7 +164,7 @@ constructor(
           )
         }
       )
-      documentedVisibilities.convention(listOf(DokkaConfiguration.Visibility.PUBLIC))
+      documentedVisibilities.convention(listOf(VisibilityModifier.DEFAULT))
       jdkVersion.convention(8)
       noAndroidSdkLink.convention(true)
       noJdkLink.convention(false)

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -4,6 +4,7 @@ import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_BASE_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_CATEGORY_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKA_FORMAT_ATTRIBUTE
+import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec.EncodedFormat
 import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
 import dev.adamko.dokkatoo.formats.*
 import dev.adamko.dokkatoo.internal.*
@@ -25,7 +26,6 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.kotlin.dsl.*
 import org.gradle.language.base.plugins.LifecycleBasePlugin
-import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.Platform
 
 /**
@@ -143,7 +143,7 @@ constructor(
       suppressObviousFunctions.convention(true)
 
       pluginsConfiguration.configureEach {
-        serializationFormat.convention(DokkaConfiguration.SerializationFormat.JSON)
+        serializationFormat.convention(EncodedFormat.JSON)
       }
     }
   }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpec.kt
@@ -37,7 +37,10 @@ abstract class DokkaExternalDocumentationLinkSpec
 @Inject
 constructor(
   private val name: String
-) : Serializable, Named {
+) :
+  DokkaParameterBuilder<DokkaParametersKxs.ExternalDocumentationLinkKxs?>,
+  Serializable,
+  Named {
 
   /**
    * Root URL of documentation to link with. **Must** contain a trailing slash.
@@ -108,7 +111,8 @@ constructor(
   @get:Input
   abstract val enabled: Property<Boolean>
 
-  internal fun build(): DokkaParametersKxs.ExternalDocumentationLinkKxs? =
+  @DokkatooInternalApi
+  override fun build(): DokkaParametersKxs.ExternalDocumentationLinkKxs? =
     if (enabled.getOrElse(true)) {
       DokkaParametersKxs.ExternalDocumentationLinkKxs(
         url = url.get(),

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaModuleDescriptionSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaModuleDescriptionSpec.kt
@@ -8,7 +8,6 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.jetbrains.dokka.DokkaConfigurationBuilder
 
 @DokkatooInternalApi
 abstract class DokkaModuleDescriptionSpec
@@ -16,7 +15,7 @@ abstract class DokkaModuleDescriptionSpec
 @Inject constructor(
   @get:Input
   val moduleName: String,
-) : DokkaConfigurationBuilder<DokkaParametersKxs.DokkaModuleDescriptionKxs>, Named {
+) : DokkaParameterBuilder<DokkaParametersKxs.DokkaModuleDescriptionKxs>, Named {
 
   @get:Input
   abstract val sourceOutputDirectory: RegularFileProperty

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
@@ -2,7 +2,7 @@
 
 package dev.adamko.dokkatoo.dokka.parameters
 
-import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.convertToDokkaType
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.convertToDokkaTypes
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import java.io.Serializable
 import org.gradle.api.provider.Property
@@ -91,7 +91,7 @@ constructor() :
   override fun build(): DokkaParametersKxs.PackageOptionsKxs =
     DokkaParametersKxs.PackageOptionsKxs(
       matchingRegex = matchingRegex.get(),
-      documentedVisibilities = documentedVisibilities.get().convertToDokkaType(),
+      documentedVisibilities = documentedVisibilities.get().convertToDokkaTypes(),
       reportUndocumented = reportUndocumented.get(),
       skipDeprecated = skipDeprecated.get(),
       suppress = suppress.get()

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
@@ -2,14 +2,13 @@
 
 package dev.adamko.dokkatoo.dokka.parameters
 
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.convertToDokkaType
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import java.io.Serializable
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.kotlin.dsl.*
-import org.jetbrains.dokka.DokkaConfiguration
-import org.jetbrains.dokka.DokkaConfigurationBuilder
 
 /**
  * Configuration builder that allows setting some options for specific packages
@@ -31,7 +30,7 @@ import org.jetbrains.dokka.DokkaConfigurationBuilder
 abstract class DokkaPackageOptionsSpec
 @DokkatooInternalApi
 constructor() :
-  DokkaConfigurationBuilder<DokkaParametersKxs.PackageOptionsKxs>,
+  DokkaParameterBuilder<DokkaParametersKxs.PackageOptionsKxs>,
   Serializable {
 
   /**
@@ -58,10 +57,10 @@ constructor() :
    *
    * Can be configured for a whole source set, see [DokkaSourceSetSpec.documentedVisibilities].
    *
-   * Default is [DokkaConfiguration.Visibility.PUBLIC].
+   * Default is [VisibilityModifier.PUBLIC].
    */
   @get:Input
-  abstract val documentedVisibilities: SetProperty<DokkaConfiguration.Visibility>
+  abstract val documentedVisibilities: SetProperty<VisibilityModifier>
 
   /**
    * Whether to document declarations annotated with [Deprecated].
@@ -88,11 +87,12 @@ constructor() :
 
 
   @DokkatooInternalApi
-  override fun build() = DokkaParametersKxs.PackageOptionsKxs(
-    matchingRegex = matchingRegex.get(),
-    documentedVisibilities = documentedVisibilities.get(),
-    reportUndocumented = reportUndocumented.get(),
-    skipDeprecated = skipDeprecated.get(),
-    suppress = suppress.get()
-  )
+  override fun build(): DokkaParametersKxs.PackageOptionsKxs =
+    DokkaParametersKxs.PackageOptionsKxs(
+      matchingRegex = matchingRegex.get(),
+      documentedVisibilities = documentedVisibilities.get().convertToDokkaType(),
+      reportUndocumented = reportUndocumented.get(),
+      skipDeprecated = skipDeprecated.get(),
+      suppress = suppress.get()
+    )
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
@@ -31,6 +31,7 @@ abstract class DokkaPackageOptionsSpec
 @DokkatooInternalApi
 constructor() :
   DokkaParameterBuilder<DokkaParametersKxs.PackageOptionsKxs>,
+  HasConfigurableVisibilityModifiers,
   Serializable {
 
   /**
@@ -60,7 +61,7 @@ constructor() :
    * Default is [VisibilityModifier.PUBLIC].
    */
   @get:Input
-  abstract val documentedVisibilities: SetProperty<VisibilityModifier>
+  abstract override val documentedVisibilities: SetProperty<VisibilityModifier>
 
   /**
    * Whether to document declarations annotated with [Deprecated].

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaParameterBuilder.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaParameterBuilder.kt
@@ -1,0 +1,17 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+
+/**
+ * Implementing classes should build a Dokka Parameters type
+ * ([DokkaParametersKxs], for example).
+ *
+ * It is equivalent to [org.jetbrains.dokka.DokkaConfigurationBuilder].
+ *
+ * (This interface is just used for alignment and is not strictly necessary.)
+ */
+@DokkatooInternalApi
+internal interface DokkaParameterBuilder<T> {
+  @DokkatooInternalApi
+  fun build(): T
+}

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPluginConfigurationSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPluginConfigurationSpec.kt
@@ -8,7 +8,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.jetbrains.dokka.DokkaConfiguration
-import org.jetbrains.dokka.DokkaConfigurationBuilder
 
 /**
  * @param[pluginFqn] Fully qualified classname of the Dokka Plugin
@@ -20,7 +19,7 @@ constructor(
   @get:Input
   val pluginFqn: String
 ) :
-  DokkaConfigurationBuilder<DokkaParametersKxs.PluginConfigurationKxs>,
+  DokkaParameterBuilder<DokkaParametersKxs.PluginConfigurationKxs>,
   Serializable,
   Named {
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPluginConfigurationSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPluginConfigurationSpec.kt
@@ -1,5 +1,7 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
+import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec.EncodedFormat.JSON
+import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec.EncodedFormat.XML
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import java.io.Serializable
 import javax.inject.Inject
@@ -24,7 +26,7 @@ constructor(
   Named {
 
   @get:Input
-  abstract val serializationFormat: Property<DokkaConfiguration.SerializationFormat>
+  abstract val serializationFormat: Property<EncodedFormat>
 
   @get:Input
   abstract val values: Property<String>
@@ -32,10 +34,25 @@ constructor(
   @DokkatooInternalApi
   override fun build() = DokkaParametersKxs.PluginConfigurationKxs(
     fqPluginName = pluginFqn,
-    serializationFormat = serializationFormat.get(),
+    serializationFormat = serializationFormat.get().dokkaType,
     values = values.get(),
   )
 
   @Internal
   override fun getName(): String = pluginFqn
+
+  /**
+   * Denotes how a [DokkaPluginConfigurationSpec] will be encoded.
+   *
+   * This should typically be [JSON]. [XML] is intended for use with the Dokka Maven plugin.
+   *
+   * @see org.jetbrains.dokka.DokkaConfiguration.SerializationFormat
+   */
+  // TODO maybe remove XML? I'm not sure it's at all useful.
+  enum class EncodedFormat(
+    internal val dokkaType: DokkaConfiguration.SerializationFormat
+  ) {
+    JSON(DokkaConfiguration.SerializationFormat.JSON),
+    XML(DokkaConfiguration.SerializationFormat.XML),
+  }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceLinkSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceLinkSpec.kt
@@ -9,7 +9,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.jetbrains.dokka.DokkaConfigurationBuilder
 
 /**
  * Configuration builder that allows adding a `source` link to each signature
@@ -29,7 +28,7 @@ import org.jetbrains.dokka.DokkaConfigurationBuilder
 abstract class DokkaSourceLinkSpec
 @DokkatooInternalApi
 constructor() :
-  DokkaConfigurationBuilder<DokkaParametersKxs.SourceLinkDefinitionKxs>,
+  DokkaParameterBuilder<DokkaParametersKxs.SourceLinkDefinitionKxs>,
   Serializable {
 
   /**

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetIDSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetIDSpec.kt
@@ -5,7 +5,6 @@ import javax.inject.Inject
 import org.gradle.api.Named
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.jetbrains.dokka.DokkaConfigurationBuilder
 import org.jetbrains.dokka.DokkaSourceSetID
 
 abstract class DokkaSourceSetIDSpec
@@ -24,7 +23,7 @@ constructor(
    */
   @get:Input
   val scopeId: String
-) : DokkaConfigurationBuilder<DokkaSourceSetID>, Named {
+) : DokkaParameterBuilder<DokkaSourceSetID>, Named {
 
   @get:Input
   abstract var sourceSetName: String

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
@@ -1,5 +1,6 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.convertToDokkaType
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import java.io.Serializable
 import java.net.URL
@@ -42,7 +43,7 @@ constructor(
   private val name: String,
   private val objects: ObjectFactory,
 ) :
-  DokkaConfigurationBuilder<DokkaParametersKxs.DokkaSourceSetKxs>,
+  DokkaParameterBuilder<DokkaParametersKxs.DokkaSourceSetKxs>,
   Named,
   Serializable {
 
@@ -117,10 +118,10 @@ constructor(
    * Default is [DokkaConfiguration.Visibility.PUBLIC].
    */
   @get:Input
-  abstract val documentedVisibilities: SetProperty<DokkaConfiguration.Visibility>
+  abstract val documentedVisibilities: SetProperty<VisibilityModifier>
 
   /** Sets [documentedVisibilities] (overrides any previously set values). */
-  fun documentedVisibilities(vararg visibilities: DokkaConfiguration.Visibility): Unit =
+  fun documentedVisibilities(vararg visibilities: VisibilityModifier): Unit =
     documentedVisibilities.set(visibilities.asList())
 
   /**
@@ -407,7 +408,7 @@ constructor(
       noJdkLink = noJdkLink.get(),
       suppressedFiles = suppressedFiles.files,
       analysisPlatform = analysisPlatform.get(),
-      documentedVisibilities = documentedVisibilities.get(),
+      documentedVisibilities = documentedVisibilities.get().convertToDokkaType(),
     )
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
@@ -1,6 +1,6 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
-import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.convertToDokkaType
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.convertToDokkaTypes
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import java.io.Serializable
 import java.net.URL
@@ -405,7 +405,7 @@ constructor(
       noJdkLink = noJdkLink.get(),
       suppressedFiles = suppressedFiles.files,
       analysisPlatform = analysisPlatform.get(),
-      documentedVisibilities = documentedVisibilities.get().convertToDokkaType(),
+      documentedVisibilities = documentedVisibilities.get().convertToDokkaTypes(),
     )
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
@@ -44,6 +44,7 @@ constructor(
   private val objects: ObjectFactory,
 ) :
   DokkaParameterBuilder<DokkaParametersKxs.DokkaSourceSetKxs>,
+  HasConfigurableVisibilityModifiers,
   Named,
   Serializable {
 
@@ -115,14 +116,10 @@ constructor(
    *
    * Can be configured on per-package basis, see [DokkaPackageOptionsSpec.documentedVisibilities].
    *
-   * Default is [DokkaConfiguration.Visibility.PUBLIC].
+   * Default is [VisibilityModifier.PUBLIC].
    */
   @get:Input
-  abstract val documentedVisibilities: SetProperty<VisibilityModifier>
-
-  /** Sets [documentedVisibilities] (overrides any previously set values). */
-  fun documentedVisibilities(vararg visibilities: VisibilityModifier): Unit =
-    documentedVisibilities.set(visibilities.asList())
+  abstract override val documentedVisibilities: SetProperty<VisibilityModifier>
 
   /**
    * Specifies source sets that current source set depends on.

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/HasConfigurableVisibilityModifiers.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/HasConfigurableVisibilityModifiers.kt
@@ -1,0 +1,14 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+
+internal interface HasConfigurableVisibilityModifiers {
+
+  @get:Input
+  val documentedVisibilities: SetProperty<VisibilityModifier>
+
+  /** Sets [documentedVisibilities] (overrides any previously set values). */
+  fun documentedVisibilities(vararg visibilities: VisibilityModifier): Unit =
+    documentedVisibilities.set(visibilities.asList())
+}

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
@@ -1,0 +1,24 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+import org.jetbrains.dokka.DokkaConfiguration
+
+enum class VisibilityModifier(
+  internal val dokkaType: DokkaConfiguration.Visibility
+) {
+  /** `public` modifier for Java, default visibility for Kotlin */
+  PUBLIC(DokkaConfiguration.Visibility.PUBLIC),
+  /** `private` modifier for both Kotlin and Java */
+  PRIVATE(DokkaConfiguration.Visibility.PRIVATE),
+  /** `protected` modifier for both Kotlin and Java */
+  PROTECTED(DokkaConfiguration.Visibility.PROTECTED),
+  /** Kotlin-specific `internal` modifier */
+  INTERNAL(DokkaConfiguration.Visibility.INTERNAL),
+  /** Java-specific package-private visibility (no modifier) */
+  PACKAGE(DokkaConfiguration.Visibility.PACKAGE),
+  ;
+
+  companion object {
+    internal fun Set<VisibilityModifier>.convertToDokkaType() =
+      mapTo(mutableSetOf(), VisibilityModifier::dokkaType)
+  }
+}

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
@@ -2,6 +2,13 @@ package dev.adamko.dokkatoo.dokka.parameters
 
 import org.jetbrains.dokka.DokkaConfiguration
 
+/**
+ * Denotes the
+ * [visibility modifier](https://kotlinlang.org/docs/visibility-modifiers.html)
+ * of a source code elements.
+ *
+ * @see org.jetbrains.dokka.DokkaConfiguration.Visibility
+ */
 enum class VisibilityModifier(
   internal val dokkaType: DokkaConfiguration.Visibility
 ) {

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
@@ -28,7 +28,7 @@ enum class VisibilityModifier(
 
     internal val DEFAULT = PUBLIC
 
-    internal fun Set<VisibilityModifier>.convertToDokkaType() =
+    internal fun Set<VisibilityModifier>.convertToDokkaTypes() =
       mapTo(mutableSetOf(), VisibilityModifier::dokkaType)
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
@@ -18,6 +18,9 @@ enum class VisibilityModifier(
   ;
 
   companion object {
+
+    internal val DEFAULT = PUBLIC
+
     internal fun Set<VisibilityModifier>.convertToDokkaType() =
       mapTo(mutableSetOf(), VisibilityModifier::dokkaType)
   }

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -10,6 +10,7 @@ import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companio
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKA_FORMAT_ATTRIBUTE
 import dev.adamko.dokkatoo.dokka.DokkaPublication
 import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec
+import dev.adamko.dokkatoo.dokka.parameters.DokkaPluginConfigurationSpec.EncodedFormat
 import dev.adamko.dokkatoo.internal.*
 import dev.adamko.dokkatoo.tasks.DokkatooGenerateTask
 import dev.adamko.dokkatoo.tasks.DokkatooPrepareModuleDescriptorTask
@@ -422,7 +423,7 @@ abstract class DokkatooFormatPlugin(
         }
       )
       pluginsConfiguration.configureEach {
-        serializationFormat.convention(DokkaConfiguration.SerializationFormat.JSON)
+        serializationFormat.convention(EncodedFormat.JSON)
       }
       //</editor-fold>
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/stringUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/stringUtils.kt
@@ -1,0 +1,11 @@
+package dev.adamko.dokkatoo.internal
+
+
+/**
+ * Title case the first char of a string.
+ *
+ * (Custom implementation because [uppercase] is deprecated, and Dokkatoo should try and be as
+ * stable as possible.)
+ */
+internal fun String.uppercaseFirstChar(): String =
+  if (isNotEmpty()) Character.toTitleCase(this[0]) + substring(1) else this

--- a/modules/dokkatoo-plugin/src/main/kotlin/workers/DokkaGeneratorWorker.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/workers/DokkaGeneratorWorker.kt
@@ -2,9 +2,7 @@ package dev.adamko.dokkatoo.workers
 
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import dev.adamko.dokkatoo.internal.LoggerAdapter
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
-import kotlin.time.nanoseconds
+import java.time.Duration
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.workers.WorkAction
@@ -19,7 +17,6 @@ import org.jetbrains.dokka.DokkaGenerator
  * that are used to generate the Dokka files. Transitive dependencies are also required.
  */
 @DokkatooInternalApi
-@OptIn(ExperimentalTime::class)
 abstract class DokkaGeneratorWorker : WorkAction<DokkaGeneratorWorker.Parameters> {
 
   @DokkatooInternalApi
@@ -44,11 +41,12 @@ abstract class DokkaGeneratorWorker : WorkAction<DokkaGeneratorWorker.Parameters
 
   @DokkatooInternalApi
   companion object {
-    // can't use kotlin.time.measureTime {} because the implementation isn't stable across Kotlin versions
+    // can't use kotlin.Duration or kotlin.time.measureTime {} because
+    // the implementation isn't stable across Kotlin versions
     private fun measureTime(block: () -> Unit): Duration =
       System.nanoTime().let { startTime ->
         block()
-        (System.nanoTime() - startTime).nanoseconds
+        Duration.ofNanos(System.nanoTime() - startTime)
       }
   }
 }


### PR DESCRIPTION
This should mean there's no more need for consumers who are using Dokkatoo via a Maven dependency to add a dependency on Dokka Core

* Replace `DokkaConfiguration.Visibility` with `VisibilityModifier`
* Replace `DokkaConfiguration.SerializationFormat` with `DokkaPluginConfigurationSpec.EncodedFormat`

Additionally, removes `kotlin.time.Duration` and `capitalize()` because they cause warnings in other versions of Kotlin.