### PR TITLE
Minimize exposure of Dokka Core types to plugin users

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
         task:
-          - check --continue
+          - "check --continue"
       fail-fast: false
     uses: ./.github/workflows/gradle_task.yml
     with:

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -89,6 +89,17 @@ public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$$seri
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceSetIdKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceSetIdKxs$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceSetIdKxs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceSetIdKxs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
 public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceLinkSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable {
 	public synthetic fun build ()Ljava/lang/Object;
 	public abstract fun getLocalDirectory ()Lorg/gradle/api/file/DirectoryProperty;
@@ -99,12 +110,16 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceLinkSpec :
 	public final fun remoteUrl (Lorg/gradle/api/provider/Provider;)V
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIDSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, org/gradle/api/Named {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIdSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable, org/gradle/api/Named {
+	public static final field Companion Ldev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIdSpec$Companion;
 	public synthetic fun build ()Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public final fun getScopeId ()Ljava/lang/String;
 	public abstract fun getSourceSetName ()Ljava/lang/String;
 	public abstract fun setSourceSetName (Ljava/lang/String;)V
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIdSpec$Companion {
 }
 
 public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, dev/adamko/dokkatoo/dokka/parameters/HasConfigurableVisibilityModifiers, java/io/Serializable, org/gradle/api/Named {
@@ -145,12 +160,12 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : 
 }
 
 public final class dev/adamko/dokkatoo/dokka/parameters/KotlinPlatform : java/lang/Enum {
+	public static final field Common Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
 	public static final field Companion Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform$Companion;
-	public static final field common Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
-	public static final field js Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
-	public static final field jvm Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
-	public static final field native Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
-	public static final field wasm Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static final field JS Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static final field JVM Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static final field Native Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static final field WASM Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
 	public final fun getKey ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
 	public static fun values ()[Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -144,6 +144,23 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : 
 	public final fun sourceLink (Lorg/gradle/api/Action;)V
 }
 
+public final class dev/adamko/dokkatoo/dokka/parameters/KotlinPlatform : java/lang/Enum {
+	public static final field Companion Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform$Companion;
+	public static final field common Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static final field js Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static final field jvm Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static final field native Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static final field wasm Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public final fun getKey ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public static fun values ()[Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/KotlinPlatform$Companion {
+	public final fun fromString (Ljava/lang/String;)Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+	public final fun getDEFAULT ()Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
+}
+
 public final class dev/adamko/dokkatoo/dokka/parameters/VisibilityModifier : java/lang/Enum {
 	public static final field Companion Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier$Companion;
 	public static final field INTERNAL Ldev/adamko/dokkatoo/dokka/parameters/VisibilityModifier;

--- a/modules/dokkatoo-plugin/build.gradle.kts
+++ b/modules/dokkatoo-plugin/build.gradle.kts
@@ -25,7 +25,9 @@ plugins {
 description = "Generates documentation for Kotlin projects (using Dokka)"
 
 dependencies {
-
+  // ideally there should be a 'dokka-core-api' dependency (that is very thin and doesn't drag in loads of unnecessary code)
+  // that would be used as an implementation dependency, while dokka-core would be used as a compileOnly dependency
+  // https://github.com/Kotlin/dokka/issues/2933
   implementation(libs.kotlin.dokkaCore)
 
   compileOnly(libs.gradlePlugin.kotlin)
@@ -118,8 +120,6 @@ testing.suites {
 
       implementation(project.dependencies.testFixtures(project()))
 
-      compileOnly(libs.kotlin.dokkaCore)
-
       implementation(project.dependencies.platform(libs.kotlinxSerialization.bom))
       implementation(libs.kotlinxSerialization.json)
     }
@@ -191,7 +191,7 @@ val aggregateTestReports by tasks.registering(TestReport::class) {
 binaryCompatibilityValidator {
   ignoredMarkers.add("dev.adamko.dokkatoo.internal.DokkatooInternalApi")
 
-  // manually ignore all KxS serializers
+  // TODO remove manually ignored KxS serializers - it's not really correct to ignore them
   ignoredClasses.addAll(
     listOf(
       "DokkaModuleDescriptionKxs",
@@ -224,14 +224,14 @@ val buildConfigFileContents: Provider<TextResource> =
 
     resources.text.fromString(
       """
-          |package dev.adamko.dokkatoo.internal
-          |
-          |@DokkatooInternalApi
-          |object DokkatooConstants {
-          |$vals
-          |}
-          |
-        """.trimMargin()
+        |package dev.adamko.dokkatoo.internal
+        |
+        |@DokkatooInternalApi
+        |object DokkatooConstants {
+        |$vals
+        |}
+        |
+      """.trimMargin()
     )
   }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -4,6 +4,7 @@ import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_BASE_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_CATEGORY_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKA_FORMAT_ATTRIBUTE
+import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
 import dev.adamko.dokkatoo.formats.*
 import dev.adamko.dokkatoo.internal.*
@@ -25,7 +26,6 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.kotlin.dsl.*
 import org.gradle.language.base.plugins.LifecycleBasePlugin
-import org.jetbrains.dokka.Platform
 
 /**
  * The base plugin for Dokkatoo. Sets up Dokkatoo and configures default values, but does not
@@ -149,7 +149,7 @@ constructor(
     val sourceSetScopeConvention = dokkatooExtension.sourceSetScopeDefault
 
     dokkatooExtension.dokkatooSourceSets.all dss@{
-      analysisPlatform.convention(Platform.DEFAULT)
+      analysisPlatform.convention(KotlinPlatform.DEFAULT)
       displayName.convention(
         analysisPlatform.map { platform ->
           name.substringBeforeLast(

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -158,7 +158,7 @@ constructor(
           )
         }
       )
-      documentedVisibilities.convention(listOf(VisibilityModifier.DEFAULT))
+      documentedVisibilities.convention(setOf(VisibilityModifier.PUBLIC))
       jdkVersion.convention(8)
       noAndroidSdkLink.convention(true)
       noJdkLink.convention(false)

--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
@@ -4,7 +4,7 @@ import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.LibraryVariant
 import dev.adamko.dokkatoo.DokkatooBasePlugin
 import dev.adamko.dokkatoo.DokkatooExtension
-import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetIDSpec
+import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetIdSpec.Companion.dokkaSourceSetIdSpec
 import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import javax.inject.Inject
@@ -100,10 +100,10 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
       val extantKotlinSourceRoots = this@kss.kotlin.sourceDirectories.filter { it.exists() }
 
       val dependentSourceSetIds = this@kss.dependsOn.map { dependedKss ->
-        objects.newInstance<DokkaSourceSetIDSpec>("${project.path}:${this@kss.name}:${dependedKss.name}")
-          .apply {
-            sourceSetName = dependedKss.name
-          }
+        objects.dokkaSourceSetIdSpec(
+          "${project.path}:${this@kss.name}:${dependedKss.name}",
+          dependedKss.name,
+        )
       }
 
       logger.info("kotlin source set ${this@kss.name} has source roots: ${extantKotlinSourceRoots.map { it.invariantSeparatorsPath }}")
@@ -113,7 +113,7 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
           analysisPlatform.map { platform ->
             name.substringBeforeLast(
               delimiter = "Main",
-              missingDelimiterValue = platform.name,
+              missingDelimiterValue = platform.key,
             )
           }
         )

--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
@@ -5,6 +5,7 @@ import com.android.build.gradle.api.LibraryVariant
 import dev.adamko.dokkatoo.DokkatooBasePlugin
 import dev.adamko.dokkatoo.DokkatooExtension
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetIDSpec
+import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import javax.inject.Inject
 import org.gradle.api.Plugin
@@ -15,11 +16,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionContainer
-import org.gradle.kotlin.dsl.findByType
-import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.newInstance
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.dokka.Platform
+import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinSingleTargetExtension
@@ -123,7 +120,7 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
         suppress.convention(!isMainSourceSet)
         sourceRoots.from(extantKotlinSourceRoots)
         classpath.from(getKSSClasspath(project, kotlinSourceSetConfigurationNames))
-        analysisPlatform.convention(Platform.fromString(kotlinPlatformType.name))
+        analysisPlatform.convention(KotlinPlatform.fromString(kotlinPlatformType.name))
         dependentSourceSets.addAll(dependentSourceSetIds)
       }
     }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaPackageOptionsSpec.kt
@@ -2,8 +2,9 @@
 
 package dev.adamko.dokkatoo.dokka.parameters
 
-import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.convertToDokkaTypes
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.dokkaType
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+import dev.adamko.dokkatoo.internal.mapToSet
 import java.io.Serializable
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
@@ -91,7 +92,7 @@ constructor() :
   override fun build(): DokkaParametersKxs.PackageOptionsKxs =
     DokkaParametersKxs.PackageOptionsKxs(
       matchingRegex = matchingRegex.get(),
-      documentedVisibilities = documentedVisibilities.get().convertToDokkaTypes(),
+      documentedVisibilities = documentedVisibilities.get().mapToSet { it.dokkaType },
       reportUndocumented = reportUndocumented.get(),
       skipDeprecated = skipDeprecated.get(),
       suppress = suppress.get()

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaParametersKxs.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaParametersKxs.kt
@@ -1,16 +1,18 @@
 @file:UseSerializers(
   FileAsPathStringSerializer::class,
-  DokkaSourceSetIDSerializer::class,
   URLSerializer::class,
 )
 
 package dev.adamko.dokkatoo.dokka.parameters
 
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+import dev.adamko.dokkatoo.internal.mapToSet
 import java.io.File
 import java.net.URL
 import java.nio.file.Paths
-import kotlinx.serialization.*
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -28,60 +30,99 @@ import org.jetbrains.dokka.*
 @Serializable
 @DokkatooInternalApi
 data class DokkaParametersKxs(
-  override val moduleName: String,
-  override val moduleVersion: String? = null,
-  // TODO outputDir is overwritten in DokkatooGenerateTask so the task's output dir can be registered properly, so this property is not used and should be hidden
-  override val outputDir: File,
-  override val cacheRoot: File? = null,
-  override val offlineMode: Boolean,
-  override val failOnWarning: Boolean,
-  override val sourceSets: List<DokkaSourceSetKxs>,
-  override val pluginsClasspath: List<File>,
-  override val pluginsConfiguration: List<PluginConfigurationKxs>,
-  override val delayTemplateSubstitution: Boolean,
-  override val suppressObviousFunctions: Boolean,
-  override val includes: Set<File>,
-  override val suppressInheritedMembers: Boolean,
-  override val finalizeCoroutines: Boolean,
+  val moduleName: String,
+  val moduleVersion: String? = null,
+  val cacheRoot: File? = null,
+  val offlineMode: Boolean,
+  val failOnWarning: Boolean,
+  val sourceSets: List<DokkaSourceSetKxs>,
+  val pluginsClasspath: List<File>,
+  val pluginsConfiguration: List<PluginConfigurationKxs>,
+  val delayTemplateSubstitution: Boolean,
+  val suppressObviousFunctions: Boolean,
+  val includes: Set<File>,
+  val suppressInheritedMembers: Boolean,
+  val finalizeCoroutines: Boolean,
 
-  val modulesKxs: List<DokkaModuleDescriptionKxs>,
-) : DokkaConfiguration, Named {
-
-  override val modules: List<DokkaConfiguration.DokkaModuleDescription>
-    get() = modulesKxs
+  val modules: List<DokkaModuleDescriptionKxs>,
+) : Named {
 
   override fun getName(): String = moduleName
+
+  fun convert(outputDir: File): DokkaConfiguration {
+    return DokkaConfigurationImpl(
+      moduleName = moduleName,
+      moduleVersion = moduleVersion,
+      outputDir = outputDir,
+      cacheRoot = cacheRoot,
+      offlineMode = offlineMode,
+      sourceSets = sourceSets.map(DokkaSourceSetKxs::convert),
+      pluginsClasspath = pluginsClasspath,
+      pluginsConfiguration = pluginsConfiguration.map(PluginConfigurationKxs::convert),
+      modules = modules.map(DokkaModuleDescriptionKxs::convert),
+      failOnWarning = failOnWarning,
+      delayTemplateSubstitution = delayTemplateSubstitution,
+      suppressObviousFunctions = suppressObviousFunctions,
+      includes = includes,
+      suppressInheritedMembers = suppressInheritedMembers,
+      finalizeCoroutines = finalizeCoroutines,
+    )
+  }
 
   @Serializable
   @DokkatooInternalApi
   data class DokkaSourceSetKxs(
-    override val sourceSetID: DokkaSourceSetID,
-    override val displayName: String,
-    override val classpath: List<File>,
-    override val sourceRoots: Set<File>,
-    override val dependentSourceSets: Set<DokkaSourceSetID>,
-    override val samples: Set<File>,
-    override val includes: Set<File>,
-    override val reportUndocumented: Boolean,
-    override val skipEmptyPackages: Boolean,
-    override val skipDeprecated: Boolean,
-    override val jdkVersion: Int,
-    override val sourceLinks: Set<SourceLinkDefinitionKxs>,
-    override val perPackageOptions: List<PackageOptionsKxs>,
-    override val externalDocumentationLinks: Set<ExternalDocumentationLinkKxs>,
-    override val languageVersion: String? = null,
-    override val apiVersion: String? = null,
-    override val noStdlibLink: Boolean,
-    override val noJdkLink: Boolean,
-    override val suppressedFiles: Set<File>,
-    override val analysisPlatform: Platform,
-    override val documentedVisibilities: Set<DokkaConfiguration.Visibility>,
-  ) : DokkaConfiguration.DokkaSourceSet, Named {
+    val sourceSetId: SourceSetIdKxs,
+    val displayName: String,
+    val classpath: List<File>,
+    val sourceRoots: Set<File>,
+    val dependentSourceSetIds: Set<SourceSetIdKxs>,
+    val samples: Set<File>,
+    val includes: Set<File>,
+    val reportUndocumented: Boolean,
+    val skipEmptyPackages: Boolean,
+    val skipDeprecated: Boolean,
+    val jdkVersion: Int,
+    val sourceLinks: Set<SourceLinkDefinitionKxs>,
+    val perPackageOptions: List<PackageOptionsKxs>,
+    val externalDocumentationLinks: Set<ExternalDocumentationLinkKxs>,
+    val languageVersion: String? = null,
+    val apiVersion: String? = null,
+    val noStdlibLink: Boolean,
+    val noJdkLink: Boolean,
+    val suppressedFiles: Set<File>,
+    val analysisPlatform: Platform,
+    val documentedVisibilities: Set<DokkaConfiguration.Visibility>,
+  ) : Named {
 
     override fun getName(): String = displayName
 
-    @Deprecated("see DokkaConfiguration.DokkaSourceSet.includeNonPublic")
-    override val includeNonPublic: Boolean = DokkaDefaults.includeNonPublic
+    internal fun convert() =
+      DokkaSourceSetImpl(
+        displayName = displayName,
+        sourceSetID = sourceSetId.convert(),
+        classpath = classpath,
+        sourceRoots = sourceRoots,
+        dependentSourceSets = dependentSourceSetIds.mapToSet(SourceSetIdKxs::convert),
+        samples = samples,
+        includes = includes,
+        reportUndocumented = reportUndocumented,
+        skipEmptyPackages = skipEmptyPackages,
+        skipDeprecated = skipDeprecated,
+        jdkVersion = jdkVersion,
+        sourceLinks = sourceLinks.mapToSet(SourceLinkDefinitionKxs::convert),
+        perPackageOptions = perPackageOptions.map(PackageOptionsKxs::convert),
+        externalDocumentationLinks = externalDocumentationLinks.mapToSet(
+          ExternalDocumentationLinkKxs::convert
+        ),
+        languageVersion = languageVersion,
+        apiVersion = apiVersion,
+        noStdlibLink = noStdlibLink,
+        noJdkLink = noJdkLink,
+        suppressedFiles = suppressedFiles,
+        analysisPlatform = analysisPlatform,
+        documentedVisibilities = documentedVisibilities,
+      )
 
     @DokkatooInternalApi
     companion object
@@ -91,10 +132,18 @@ data class DokkaParametersKxs(
   @Serializable
   @DokkatooInternalApi
   data class SourceLinkDefinitionKxs(
-    override val localDirectory: String,
-    override val remoteUrl: URL,
-    override val remoteLineSuffix: String? = null,
-  ) : DokkaConfiguration.SourceLinkDefinition {
+    val localDirectory: String,
+    val remoteUrl: URL,
+    val remoteLineSuffix: String? = null,
+  ) {
+
+    internal fun convert() =
+      SourceLinkDefinitionImpl(
+        localDirectory = localDirectory,
+        remoteUrl = remoteUrl,
+        remoteLineSuffix = remoteLineSuffix,
+      )
+
     @DokkatooInternalApi
     companion object
   }
@@ -103,15 +152,20 @@ data class DokkaParametersKxs(
   @Serializable
   @DokkatooInternalApi
   data class PackageOptionsKxs(
-    override val matchingRegex: String,
-    override val reportUndocumented: Boolean? = null,
-    override val skipDeprecated: Boolean,
-    override val suppress: Boolean,
-    override val documentedVisibilities: Set<DokkaConfiguration.Visibility>,
-  ) : DokkaConfiguration.PackageOptions {
-
-    @Deprecated("see DokkaConfiguration.PackageOptions.includeNonPublic")
-    override val includeNonPublic: Boolean = DokkaDefaults.includeNonPublic
+    val matchingRegex: String,
+    val reportUndocumented: Boolean? = null,
+    val skipDeprecated: Boolean,
+    val suppress: Boolean,
+    val documentedVisibilities: Set<DokkaConfiguration.Visibility>,
+  ) {
+    internal fun convert() = PackageOptionsImpl(
+      matchingRegex = matchingRegex,
+      reportUndocumented = reportUndocumented,
+      skipDeprecated = skipDeprecated,
+      suppress = suppress,
+      documentedVisibilities = documentedVisibilities,
+      includeNonPublic = DokkaDefaults.includeNonPublic,
+    )
 
     @DokkatooInternalApi
     companion object
@@ -121,11 +175,17 @@ data class DokkaParametersKxs(
   @Serializable
   @DokkatooInternalApi
   data class PluginConfigurationKxs(
-    override val fqPluginName: String,
-    override val serializationFormat: DokkaConfiguration.SerializationFormat,
-    // a string that might contain escaped JSON/XML
-    override val values: String,
-  ) : DokkaConfiguration.PluginConfiguration {
+    val fqPluginName: String,
+    val serializationFormat: DokkaConfiguration.SerializationFormat,
+    /** plugin configuration encoded as a string that might contain escaped JSON/XML */
+    val values: String,
+  ) {
+    fun convert() = PluginConfigurationImpl(
+      fqPluginName = fqPluginName,
+      serializationFormat = serializationFormat,
+      values = values
+    )
+
     @DokkatooInternalApi
     companion object
   }
@@ -147,71 +207,66 @@ data class DokkaParametersKxs(
   @DokkatooInternalApi
   data class DokkaModuleDescriptionKxs(
     /** @see DokkaConfiguration.DokkaModuleDescription.name */
-    override val name: String,
+    val name: String,
     /**
      * Location of the Dokka Module directory for a subproject.
      *
      * @see DokkaConfiguration.DokkaModuleDescription.sourceOutputDirectory
      */
-    override val sourceOutputDirectory: File,
+    val sourceOutputDirectory: File,
     /** @see DokkaConfiguration.DokkaModuleDescription.includes */
-    override val includes: Set<File>,
+    val includes: Set<File>,
 
     /** @see [org.gradle.api.Project.getPath] */
     val modulePath: String,
-  ) : DokkaConfiguration.DokkaModuleDescription {
+  ) {
 
-    override val relativePathToOutputDirectory =
-      File(modulePath.removePrefix(":").replace(':', '/'))
+    internal fun convert() = DokkaModuleDescriptionImpl(
+      name = name,
+      relativePathToOutputDirectory = File(modulePath.removePrefix(":").replace(':', '/')),
+      includes = includes,
+      sourceOutputDirectory = sourceOutputDirectory,
+    )
 
     @DokkatooInternalApi
-    companion object
+    internal companion object
   }
 
 
   @Serializable
   @DokkatooInternalApi
   data class ExternalDocumentationLinkKxs(
-    override val url: URL,
-    override val packageListUrl: URL,
-  ) : DokkaConfiguration.ExternalDocumentationLink {
+    val url: URL,
+    val packageListUrl: URL,
+  ) {
+    internal fun convert() =
+      ExternalDocumentationLinkImpl(
+        url = url,
+        packageListUrl = packageListUrl,
+      )
+
     @DokkatooInternalApi
     companion object
   }
 
-  @DokkatooInternalApi
-  companion object
-}
-
-
-/** Serializer for [DokkaSourceSetID] */
-private object DokkaSourceSetIDSerializer : KSerializer<DokkaSourceSetID> {
-
   @Serializable
-  private data class DokkaSourceSetIDDelegate(
+  @DokkatooInternalApi
+  /**
+   * @see org.jetbrains.dokka.DokkaSourceSetID
+   */
+  data class SourceSetIdKxs(
     val scopeId: String,
     val sourceSetName: String,
-  )
+  ) {
+    fun convert() = DokkaSourceSetID(scopeId, sourceSetName)
 
-  private val delegateSerializer = DokkaSourceSetIDDelegate.serializer()
-
-  override val descriptor: SerialDescriptor = delegateSerializer.descriptor
-
-  override fun deserialize(decoder: Decoder): DokkaSourceSetID {
-    val delegate = decoder.decodeSerializableValue(delegateSerializer)
-    return DokkaSourceSetID(
-      scopeId = delegate.scopeId,
-      sourceSetName = delegate.sourceSetName,
-    )
+    @DokkatooInternalApi
+    companion object
   }
 
-  override fun serialize(encoder: Encoder, value: DokkaSourceSetID) {
-    val delegate = DokkaSourceSetIDDelegate(
-      scopeId = value.scopeId,
-      sourceSetName = value.sourceSetName,
-    )
-    encoder.encodeSerializableValue(delegateSerializer, delegate)
-  }
+
+  @DokkatooInternalApi
+  companion object
 }
 
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetIdSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetIdSpec.kt
@@ -1,13 +1,15 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+import java.io.Serializable
 import javax.inject.Inject
 import org.gradle.api.Named
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.jetbrains.dokka.DokkaSourceSetID
+import org.gradle.kotlin.dsl.*
 
-abstract class DokkaSourceSetIDSpec
+abstract class DokkaSourceSetIdSpec
 @DokkatooInternalApi
 @Inject
 constructor(
@@ -23,15 +25,29 @@ constructor(
    */
   @get:Input
   val scopeId: String
-) : DokkaParameterBuilder<DokkaSourceSetID>, Named {
+) : DokkaParameterBuilder<DokkaParametersKxs.SourceSetIdKxs>, Named, Serializable {
 
   @get:Input
   abstract var sourceSetName: String
 
   @DokkatooInternalApi
-  override fun build(): DokkaSourceSetID = DokkaSourceSetID(scopeId, sourceSetName)
+  override fun build(): DokkaParametersKxs.SourceSetIdKxs =
+    DokkaParametersKxs.SourceSetIdKxs(scopeId, sourceSetName)
 
   @Internal
   override fun getName(): String = scopeId
 
+  companion object {
+
+    /** Utility for creating a new [DokkaSourceSetIdSpec] instance using [ObjectFactory.newInstance] */
+    @DokkatooInternalApi
+    fun ObjectFactory.dokkaSourceSetIdSpec(
+      scopeId: String,
+      sourceSetName: String,
+    ): DokkaSourceSetIdSpec =
+      newInstance<DokkaSourceSetIdSpec>(scopeId).apply {
+        this.sourceSetName = sourceSetName
+      }
+
+  }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
@@ -211,7 +211,7 @@ constructor(
    * The default value is deduced from information provided by the Kotlin Gradle plugin.
    */
   @get:Input
-  abstract val analysisPlatform: Property<Platform>
+  abstract val analysisPlatform: Property<KotlinPlatform>
 
   /**
    * Whether to skip packages that contain no visible declarations after
@@ -404,7 +404,7 @@ constructor(
       noStdlibLink = noStdlibLink.get(),
       noJdkLink = noJdkLink.get(),
       suppressedFiles = suppressedFiles.files,
-      analysisPlatform = analysisPlatform.get(),
+      analysisPlatform = analysisPlatform.get().dokkaType,
       documentedVisibilities = documentedVisibilities.get().convertToDokkaTypes(),
     )
   }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/KotlinPlatform.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/KotlinPlatform.kt
@@ -1,0 +1,38 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+import org.jetbrains.dokka.Platform
+
+
+/**
+ * @see org.jetbrains.dokka.Platform
+ */
+@Suppress("EnumEntryName") // use lowercase names to match Dokka
+enum class KotlinPlatform(
+  internal val dokkaType: Platform
+) {
+  jvm(Platform.jvm),
+  js(Platform.js),
+  wasm(Platform.wasm),
+  native(Platform.native),
+  common(Platform.common),
+  ;
+
+  val key: String by dokkaType::key
+
+  companion object {
+    internal val entries: Set<KotlinPlatform> = values().toSet()
+
+    val DEFAULT: KotlinPlatform = entries.first { it.dokkaType == Platform.DEFAULT }
+
+    fun fromString(key: String): KotlinPlatform {
+      return when (key.toLowerCase()) {
+        jvm.key, "androidjvm", "android" -> jvm
+        js.key                           -> js
+        wasm.key                         -> wasm
+        native.key                       -> native
+        common.key, "metadata"           -> common
+        else                             -> error("Unrecognized platform: $key")
+      }
+    }
+  }
+}

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/KotlinPlatform.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/KotlinPlatform.kt
@@ -4,35 +4,46 @@ import org.jetbrains.dokka.Platform
 
 
 /**
+ * The Kotlin
+ *
  * @see org.jetbrains.dokka.Platform
  */
-@Suppress("EnumEntryName") // use lowercase names to match Dokka
-enum class KotlinPlatform(
-  internal val dokkaType: Platform
-) {
-  jvm(Platform.jvm),
-  js(Platform.js),
-  wasm(Platform.wasm),
-  native(Platform.native),
-  common(Platform.common),
+enum class KotlinPlatform {
+  JVM,
+  JS,
+  WASM,
+  Native,
+  Common,
   ;
 
-  val key: String by dokkaType::key
+  val key: String = name.toLowerCase()
 
   companion object {
     internal val entries: Set<KotlinPlatform> = values().toSet()
 
-    val DEFAULT: KotlinPlatform = entries.first { it.dokkaType == Platform.DEFAULT }
+    val DEFAULT: KotlinPlatform = JVM
 
     fun fromString(key: String): KotlinPlatform {
+
       return when (key.toLowerCase()) {
-        jvm.key, "androidjvm", "android" -> jvm
-        js.key                           -> js
-        wasm.key                         -> wasm
-        native.key                       -> native
-        common.key, "metadata"           -> common
+        JVM.key, "androidjvm", "android" -> JVM
+        JS.key                           -> JS
+        WASM.key                         -> WASM
+        Native.key                       -> Native
+        Common.key, "metadata"           -> Common
         else                             -> error("Unrecognized platform: $key")
       }
     }
+
+    // Not defined as a property to try and minimize the dependency on Dokka Core types
+    internal val KotlinPlatform.dokkaType: Platform
+      get() =
+        when (this) {
+          JVM    -> Platform.jvm
+          JS     -> Platform.js
+          WASM   -> Platform.wasm
+          Native -> Platform.native
+          Common -> Platform.common
+        }
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
@@ -9,27 +9,39 @@ import org.jetbrains.dokka.DokkaConfiguration
  *
  * @see org.jetbrains.dokka.DokkaConfiguration.Visibility
  */
-enum class VisibilityModifier(
-  internal val dokkaType: DokkaConfiguration.Visibility
-) {
+enum class VisibilityModifier {
   /** `public` modifier for Java, default visibility for Kotlin */
-  PUBLIC(DokkaConfiguration.Visibility.PUBLIC),
+  PUBLIC,
+
   /** `private` modifier for both Kotlin and Java */
-  PRIVATE(DokkaConfiguration.Visibility.PRIVATE),
+  PRIVATE,
+
   /** `protected` modifier for both Kotlin and Java */
-  PROTECTED(DokkaConfiguration.Visibility.PROTECTED),
+  PROTECTED,
+
   /** Kotlin-specific `internal` modifier */
-  INTERNAL(DokkaConfiguration.Visibility.INTERNAL),
+  INTERNAL,
+
   /** Java-specific package-private visibility (no modifier) */
-  PACKAGE(DokkaConfiguration.Visibility.PACKAGE),
+  PACKAGE,
   ;
 
   companion object {
     internal val entries: Set<VisibilityModifier> = values().toSet()
 
+    @Deprecated("internal value, no longer in use. The default value was moved to DokkaBasePlugin.configureDokkatooSourceSetsDefaults()")
+    @Suppress("unused")
     internal val DEFAULT: VisibilityModifier = PUBLIC
 
-    internal fun Set<VisibilityModifier>.convertToDokkaTypes() =
-      mapTo(mutableSetOf(), VisibilityModifier::dokkaType)
+    // Not defined as a property to try and minimize the dependency on Dokka Core types
+    internal val VisibilityModifier.dokkaType: DokkaConfiguration.Visibility
+      get() =
+        when (this) {
+          PUBLIC    -> DokkaConfiguration.Visibility.PUBLIC
+          PRIVATE   -> DokkaConfiguration.Visibility.PRIVATE
+          PROTECTED -> DokkaConfiguration.Visibility.PROTECTED
+          INTERNAL  -> DokkaConfiguration.Visibility.INTERNAL
+          PACKAGE   -> DokkaConfiguration.Visibility.PACKAGE
+        }
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/VisibilityModifier.kt
@@ -25,8 +25,9 @@ enum class VisibilityModifier(
   ;
 
   companion object {
+    internal val entries: Set<VisibilityModifier> = values().toSet()
 
-    internal val DEFAULT = PUBLIC
+    internal val DEFAULT: VisibilityModifier = PUBLIC
 
     internal fun Set<VisibilityModifier>.convertToDokkaTypes() =
       mapTo(mutableSetOf(), VisibilityModifier::dokkaType)

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/migrations.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/migrations.kt
@@ -1,0 +1,8 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+@Deprecated(
+  "renamed, and removed Dokka Core interface inheritance",
+  ReplaceWith("DokkaSourceSetIdSpec"),
+)
+@Suppress("unused")
+typealias DokkaSourceSetIDSpec = DokkaSourceSetIdSpec

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -398,7 +398,6 @@ abstract class DokkatooFormatPlugin(
       moduleName.convention(publication.moduleName)
       moduleVersion.convention(publication.moduleVersion)
       offlineMode.convention(publication.offlineMode)
-      outputDir.convention(publication.outputDir)
       pluginsClasspath.from(
         dependencyContainers.dokkaPluginsIntransitiveClasspath.map { classpath ->
           classpath.incoming.artifacts.artifactFiles

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/collectionsUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/collectionsUtils.kt
@@ -1,0 +1,4 @@
+package dev.adamko.dokkatoo.internal
+
+internal fun <T, R> Set<T>.mapToSet(transform: (T) -> R): Set<R> =
+  mapTo(mutableSetOf(), transform)

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/KotlinPlatformTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/KotlinPlatformTest.kt
@@ -1,5 +1,6 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
+import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform.Companion.dokkaType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.shouldForAll
 import io.kotest.matchers.collections.shouldBeIn

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/KotlinPlatformTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/KotlinPlatformTest.kt
@@ -1,0 +1,36 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.shouldForAll
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.shouldBe
+import org.jetbrains.dokka.Platform
+
+class KotlinPlatformTest : FunSpec({
+
+  test("should have same default as Dokka type") {
+    KotlinPlatform.DEFAULT.dokkaType shouldBe Platform.DEFAULT
+  }
+
+  test("Dokka platform should have equivalent KotlinPlatform") {
+
+    Platform.values().shouldForAll { dokkaPlatform ->
+      dokkaPlatform shouldBeIn KotlinPlatform.entries.map { it.dokkaType }
+    }
+  }
+
+  test("platform strings should map to same KotlinPlatform and Platform") {
+    listOf(
+      "androidJvm",
+      "android",
+      "metadata",
+      "jvm",
+      "js",
+      "wasm",
+      "native",
+      "common",
+    ).shouldForAll {
+      Platform.fromString(it) shouldBe KotlinPlatform.fromString(it).dokkaType
+    }
+  }
+})

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/VisibilityModifierTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/VisibilityModifierTest.kt
@@ -1,0 +1,20 @@
+package dev.adamko.dokkatoo.dokka.parameters
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.shouldForAll
+import io.kotest.inspectors.shouldForOne
+import io.kotest.matchers.shouldBe
+import org.jetbrains.dokka.DokkaConfiguration
+
+class VisibilityModifierTest : FunSpec({
+
+  test("expect default is PUBLIC") {
+    VisibilityModifier.DEFAULT shouldBe VisibilityModifier.PUBLIC
+  }
+
+  test("DokkaConfiguration.Visibility should have equivalent VisibilityModifier") {
+    DokkaConfiguration.Visibility.values().shouldForAll { dokkaVisibility ->
+      VisibilityModifier.entries.map { it.dokkaType }.shouldForOne { it shouldBe dokkaVisibility }
+    }
+  }
+})

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/VisibilityModifierTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/VisibilityModifierTest.kt
@@ -1,5 +1,6 @@
 package dev.adamko.dokkatoo.dokka.parameters
 
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.dokkaType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.shouldForAll
 import io.kotest.inspectors.shouldForOne
@@ -7,10 +8,6 @@ import io.kotest.matchers.shouldBe
 import org.jetbrains.dokka.DokkaConfiguration
 
 class VisibilityModifierTest : FunSpec({
-
-  test("expect default is PUBLIC") {
-    VisibilityModifier.DEFAULT shouldBe VisibilityModifier.PUBLIC
-  }
 
   test("DokkaConfiguration.Visibility should have equivalent VisibilityModifier") {
     DokkaConfiguration.Visibility.values().shouldForAll { dokkaVisibility ->


### PR DESCRIPTION
once again, minimise (public) dependencies on Dokka Core classes, so consumers shouldn't need to depend on Dokka Core for plugin configuration

### Breaking changes

* Replace Dokka Core `Platform` to enum, `KotlinPlatform` (impacts `DokkaSourceSetSpec.analysisPlatform`)
* Replace DokkaCore class `DokkaSourceSetID` with project type `DokkaSourceSetIdSpec` (impacts `DokkaSourceSetSpec.sourceSetID` and `DokkaSourceSetSpec.dependentSourceSets`)

Both of these types are identical to the Dokka Core types, so updating them is easy.

### Deprecations

* deprecate unnecessary 'outputDir' in `DokkatooPrepareParametersTask` task
