### PR TITLE
remove KxS BCV exclusion, and unmark some companion objects as internal

### DIFF
--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -37,6 +37,9 @@ public abstract class dev/adamko/dokkatoo/DokkatooPlugin : org/gradle/api/Plugin
 	public fun apply (Lorg/gradle/api/Project;)V
 }
 
+public final class dev/adamko/dokkatoo/adapters/DokkatooKotlinAdapter$Companion {
+}
+
 public abstract class dev/adamko/dokkatoo/dokka/DokkaPublication : java/io/Serializable, org/gradle/api/Named {
 	public abstract fun getCacheRoot ()Lorg/gradle/api/file/DirectoryProperty;
 	protected final fun getCacheRootPath ()Lorg/gradle/api/provider/Provider;
@@ -89,6 +92,100 @@ public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$$seri
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaModuleDescriptionKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaModuleDescriptionKxs$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaModuleDescriptionKxs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaModuleDescriptionKxs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaModuleDescriptionKxs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaSourceSetKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaSourceSetKxs$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaSourceSetKxs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaSourceSetKxs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$DokkaSourceSetKxs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$ExternalDocumentationLinkKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$ExternalDocumentationLinkKxs$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$ExternalDocumentationLinkKxs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$ExternalDocumentationLinkKxs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$ExternalDocumentationLinkKxs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PackageOptionsKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PackageOptionsKxs$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PackageOptionsKxs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PackageOptionsKxs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PackageOptionsKxs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PluginConfigurationKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PluginConfigurationKxs$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PluginConfigurationKxs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PluginConfigurationKxs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$PluginConfigurationKxs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceLinkDefinitionKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceLinkDefinitionKxs$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceLinkDefinitionKxs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceLinkDefinitionKxs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceLinkDefinitionKxs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceSetIdKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceSetIdKxs$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
@@ -98,6 +195,10 @@ public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$Sourc
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceSetIdKxs;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/adamko/dokkatoo/dokka/parameters/DokkaParametersKxs$SourceSetIdKxs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceLinkSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, java/io/Serializable {
@@ -309,7 +410,6 @@ public final class dev/adamko/dokkatoo/dokka/plugins/PluginConfigValue$Values : 
 }
 
 public abstract class dev/adamko/dokkatoo/formats/DokkatooFormatPlugin : org/gradle/api/Plugin {
-	public static final field Companion Ldev/adamko/dokkatoo/formats/DokkatooFormatPlugin$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/Project;)V

--- a/modules/dokkatoo-plugin/build.gradle.kts
+++ b/modules/dokkatoo-plugin/build.gradle.kts
@@ -190,19 +190,6 @@ val aggregateTestReports by tasks.registering(TestReport::class) {
 
 binaryCompatibilityValidator {
   ignoredMarkers.add("dev.adamko.dokkatoo.internal.DokkatooInternalApi")
-
-  // TODO remove manually ignored KxS serializers - it's not really correct to ignore them
-  ignoredClasses.addAll(
-    listOf(
-      "DokkaModuleDescriptionKxs",
-      "DokkaSourceSetKxs",
-      "ExternalDocumentationLinkKxs",
-      "PackageOptionsKxs",
-      "PluginConfigurationKxs",
-      "SourceLinkDefinitionKxs",
-    ).map {
-      "dev.adamko.dokkatoo.dokka.parameters.DokkaParametersKxs\$$it\$\$serializer"
-    })
 }
 
 val dokkatooVersion = provider { project.version.toString() }

--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
@@ -151,7 +151,6 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
     return classpathCollector
   }
 
-  @DokkatooInternalApi
   companion object {
 
     private fun KotlinProjectExtension.kotlinPlatformType(): KotlinPlatformType {

--- a/modules/dokkatoo-plugin/src/main/kotlin/distibutions/DokkatooConfigurationAttributes.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/distibutions/DokkatooConfigurationAttributes.kt
@@ -22,7 +22,6 @@ constructor(
 ) {
 
   /** A general attribute for all [Configuration]s that are used by the Dokka Gradle plugin */
-//    val dokkaBaseUsage: Usage = objects.named("org.jetbrains.dokka")
   val dokkatooBaseUsage: DokkatooBaseAttribute = objects.named("dokkatoo")
 
   /** for [Configuration]s that provide or consume Dokka parameter files */

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaParametersKxs.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaParametersKxs.kt
@@ -123,9 +123,6 @@ data class DokkaParametersKxs(
         analysisPlatform = analysisPlatform,
         documentedVisibilities = documentedVisibilities,
       )
-
-    @DokkatooInternalApi
-    companion object
   }
 
 
@@ -143,9 +140,6 @@ data class DokkaParametersKxs(
         remoteUrl = remoteUrl,
         remoteLineSuffix = remoteLineSuffix,
       )
-
-    @DokkatooInternalApi
-    companion object
   }
 
 
@@ -166,9 +160,6 @@ data class DokkaParametersKxs(
       documentedVisibilities = documentedVisibilities,
       includeNonPublic = DokkaDefaults.includeNonPublic,
     )
-
-    @DokkatooInternalApi
-    companion object
   }
 
 
@@ -185,9 +176,6 @@ data class DokkaParametersKxs(
       serializationFormat = serializationFormat,
       values = values
     )
-
-    @DokkatooInternalApi
-    companion object
   }
 
 
@@ -227,9 +215,6 @@ data class DokkaParametersKxs(
       includes = includes,
       sourceOutputDirectory = sourceOutputDirectory,
     )
-
-    @DokkatooInternalApi
-    internal companion object
   }
 
 
@@ -244,9 +229,6 @@ data class DokkaParametersKxs(
         url = url,
         packageListUrl = packageListUrl,
       )
-
-    @DokkatooInternalApi
-    companion object
   }
 
   @Serializable
@@ -259,14 +241,7 @@ data class DokkaParametersKxs(
     val sourceSetName: String,
   ) {
     fun convert() = DokkaSourceSetID(scopeId, sourceSetName)
-
-    @DokkatooInternalApi
-    companion object
   }
-
-
-  @DokkatooInternalApi
-  companion object
 }
 
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -463,7 +463,4 @@ abstract class DokkatooFormatPlugin(
 //      }
     }
   }
-
-  @DokkatooInternalApi
-  companion object
 }


### PR DESCRIPTION
Include KxS and some companion objects in the BCV api dump.

Excluding them wasn't really necessary in the first place. While it's best if KxS was kept completely internal and not exposed in the public API, that's not possible, and so KxS should be represented in the public API.