### PR TITLE
fix adding compile-time Kotlin dependencies to Dokka Source Set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.adamko.dokkatoo"
-version = "1.1.0"
+version = "1.1.1-SNAPSHOT"
 
 
 idea {

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -43,7 +43,8 @@ tasks.dokkatooGeneratePublicationHtml {
                 <div id="github-link"><a href="https://github.com/adamko-dev/dokkatoo/"></a></div>
                 <button id="theme-toggle-button">
               """.trimIndent(),
-            ).replace(
+            )
+            .replace(
               """
                 href="https://github.com/Kotlin/dokka"><span>dokka</span>
               """.trimIndent(),

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -6,7 +6,6 @@ import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companio
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKA_FORMAT_ATTRIBUTE
 import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
-import dev.adamko.dokkatoo.formats.*
 import dev.adamko.dokkatoo.internal.*
 import dev.adamko.dokkatoo.tasks.DokkatooGenerateTask
 import dev.adamko.dokkatoo.tasks.DokkatooPrepareModuleDescriptorTask
@@ -19,7 +18,6 @@ import kotlinx.serialization.json.Json
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.attributes.*
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
@@ -42,13 +42,14 @@ internal fun Configuration.asConsumer() {
 internal operator fun Provider<Boolean>.not(): Provider<Boolean> = map { !it }
 
 
-/**
- * Only matches components that come from subprojects
- */
+/** Only matches components that come from subprojects */
 internal object LocalProjectOnlyFilter : Spec<ComponentIdentifier> {
   override fun isSatisfiedBy(element: ComponentIdentifier?): Boolean =
     element is ProjectComponentIdentifier
 }
+
+/** Invert the result of a [Spec] predicate */
+internal operator fun <T> Spec<T>.not() = Spec<T> { !this@not.isSatisfiedBy(it) }
 
 
 internal fun Project.pathAsFilePath() = path

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -78,22 +78,30 @@ fun gradleKtsProjectTest(
   return GradleProjectTest(baseDir = baseDir, testProjectName = testProjectName).apply {
 
     settingsGradleKts = """
-      |rootProject.name = "test"
+      |rootProject.name = "$testProjectName"
       |
       |@Suppress("UnstableApiUsage")
       |dependencyResolutionManagement {
-      |    repositories {
-      |        mavenCentral()
-      |        maven(file("$testMavenRepoRelativePath"))
+      |  repositories {
+      |    mavenCentral()
+      |    maven(file("$testMavenRepoRelativePath")) {
+      |      mavenContent {
+      |        includeGroup("dev.adamko.dokkatoo")
+      |      }
       |    }
+      |  }
       |}
       |
       |pluginManagement {
-      |    repositories {
-      |        gradlePluginPortal()
-      |        mavenCentral()
-      |        maven(file("$testMavenRepoRelativePath"))
+      |  repositories {
+      |    gradlePluginPortal()
+      |    mavenCentral()
+      |    maven(file("$testMavenRepoRelativePath")) {
+      |      mavenContent {
+      |        includeGroup("dev.adamko.dokkatoo")
+      |      }
       |    }
+      |  }
       |}
       |
     """.trimMargin()

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -78,7 +78,7 @@ fun gradleKtsProjectTest(
   return GradleProjectTest(baseDir = baseDir, testProjectName = testProjectName).apply {
 
     settingsGradleKts = """
-      |rootProject.name = "$testProjectName"
+      |rootProject.name = "test"
       |
       |@Suppress("UnstableApiUsage")
       |dependencyResolutionManagement {

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/GradlePluginProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/GradlePluginProjectIntegrationTest.kt
@@ -1,0 +1,108 @@
+package dev.adamko.dokkatoo
+
+import dev.adamko.dokkatoo.internal.DokkatooConstants
+import dev.adamko.dokkatoo.utils.*
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.shouldForAll
+import io.kotest.matchers.sequences.shouldNotBeEmpty
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+class GradlePluginProjectIntegrationTest : FunSpec({
+
+  context("given a gradle plugin project") {
+    val project = initGradlePluginProject()
+
+    val dokkatooBuild = project.runner
+      .withArguments(
+        "clean",
+        "dokkatooGeneratePublicationHtml",
+        "--stacktrace",
+      )
+      .forwardOutput()
+      .build()
+
+    test("expect project builds successfully") {
+      dokkatooBuild.output shouldContain "BUILD SUCCESSFUL"
+    }
+
+    test("expect no 'unknown class' message in HTML files") {
+      val htmlFiles = project.projectDir.toFile()
+        .resolve("build/dokka/html")
+        .walk()
+        .filter { it.isFile && it.extension == "html" }
+
+      htmlFiles.shouldNotBeEmpty()
+
+      htmlFiles.shouldForAll {
+        withClue("${it.relativeTo(project.projectDir.toFile())} should not contain Error class: unknown class") {
+          it.useLines { lines ->
+            lines.shouldForAll { line -> line.shouldNotContain("Error class: unknown class") }
+          }
+        }
+      }
+    }
+  }
+})
+
+private fun initGradlePluginProject(
+  config: GradleProjectTest.() -> Unit = {},
+): GradleProjectTest {
+  return gradleKtsProjectTest("gradle-plugin-project") {
+
+    settingsGradleKts += """
+      |
+    """.trimMargin()
+
+    buildGradleKts = """
+      |plugins {
+      |  `kotlin-dsl`
+      |  id("dev.adamko.dokkatoo") version "${DokkatooConstants.DOKKATOO_VERSION}"
+      |}
+      |
+    """.trimMargin()
+
+    dir("src/main/kotlin") {
+
+      createKotlinFile(
+        "MyCustomGradlePlugin.kt",
+        """
+          |package com.project.gradle.plugin
+          |
+          |import javax.inject.Inject
+          |import org.gradle.api.Plugin
+          |import org.gradle.api.Project
+          |import org.gradle.api.model.ObjectFactory
+          |import org.gradle.kotlin.dsl.*
+          |
+          |abstract class MyCustomGradlePlugin @Inject constructor(
+          |  private val objects: ObjectFactory
+          |) : Plugin<Project> {
+          |  override fun apply(project: Project) {
+          |    println(objects.property<String>().getOrElse("empty"))
+          |  }
+          |}
+
+        """.trimMargin()
+      )
+
+      createKotlinFile(
+        "MyCustomGradlePluginExtension.kt",
+        """
+          |package com.project.gradle.plugin
+          |
+          |import org.gradle.api.provider.*
+          |
+          |interface MyCustomGradlePluginExtension {
+          |  val versionProperty: Property<String>
+          |  val versionProvider: Provider<String>
+          |}
+          |
+        """.trimMargin()
+      )
+    }
+
+    config()
+  }
+}

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/GradlePluginProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/GradlePluginProjectIntegrationTest.kt
@@ -35,9 +35,10 @@ class GradlePluginProjectIntegrationTest : FunSpec({
 
       htmlFiles.shouldNotBeEmpty()
 
-      htmlFiles.shouldForAll {
-        withClue("${it.relativeTo(project.projectDir.toFile())} should not contain Error class: unknown class") {
-          it.useLines { lines ->
+      htmlFiles.forEach { htmlFile ->
+        val relativePath = htmlFile.relativeTo(project.projectDir.toFile())
+        withClue("$relativePath should not contain Error class: unknown class") {
+          htmlFile.useLines { lines ->
             lines.shouldForAll { line -> line.shouldNotContain("Error class: unknown class") }
           }
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,8 +41,7 @@ include(
 
   ":modules:dokkatoo-plugin",
   ":modules:dokkatoo-plugin-integration-tests",
-
-  )
+)
 
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
- fix component filter so that it only excludes local projects, and doesn't require module components
- use `resolvedArtifacts` provider API
- add compileDependencyConfigurationName to kotlinSourceSetConfigurationNames

fixes #44 