### PR TITLE
Fix: don't filter subprojects out from a KSS classpath

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
@@ -8,7 +8,6 @@ import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetIdSpec
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetIdSpec.Companion.dokkaSourceSetIdSpec
 import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
-import dev.adamko.dokkatoo.internal.LocalProjectOnlyFilter
 import dev.adamko.dokkatoo.internal.not
 import javax.inject.Inject
 import org.gradle.api.Named
@@ -225,10 +224,8 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
             @Suppress("UnstableApiUsage")
             conf
               .incoming
-              .artifactView {
-                componentFilter(!LocalProjectOnlyFilter)
-                lenient(true)
-              }.artifacts
+              .artifactView { lenient(true) }
+              .artifacts
               .resolvedArtifacts
               .map { artifacts -> artifacts.map { it.file } }
           )


### PR DESCRIPTION
Don't filter subprojects out of the auto-detected Kotlin classpath. I don't know why I put this in originally, but removing it doesn't seem to hurt, and it might fix #57.