### PR TITLE
Refactor DokkatooKotlinAdapter, fix AndroidJVM target, add DokkatooAndroidAdapter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import buildsrc.utils.initIdeProjectLogo
 
 plugins {
   buildsrc.conventions.base
-
   idea
 }
 
@@ -13,8 +12,6 @@ version = "1.2.1-SNAPSHOT"
 
 idea {
   module {
-    isDownloadSources = true
-    isDownloadJavadoc = false
     excludeGeneratedGradleDsl(layout)
 
     excludeDirs.apply {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "dev.adamko.dokkatoo"
-version = "1.2.1-SNAPSHOT"
+version = "1.3.0-SNAPSHOT"
 
 
 idea {

--- a/examples/custom-format-example/dokkatoo/build.gradle.kts
+++ b/examples/custom-format-example/dokkatoo/build.gradle.kts
@@ -2,7 +2,7 @@ import dev.adamko.dokkatoo.dokka.plugins.DokkaHtmlPluginParameters
 
 plugins {
   kotlin("jvm") version "1.8.10"
-  id("dev.adamko.dokkatoo") version "1.2.1-SNAPSHOT"
+  id("dev.adamko.dokkatoo") version "1.3.0-SNAPSHOT"
 }
 
 dokkatoo {

--- a/examples/gradle-example/dokkatoo/build.gradle.kts
+++ b/examples/gradle-example/dokkatoo/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   kotlin("jvm") version "1.8.10"
-  id("dev.adamko.dokkatoo") version "1.2.1-SNAPSHOT"
+  id("dev.adamko.dokkatoo") version "1.3.0-SNAPSHOT"
 }
 
 dokkatoo {

--- a/examples/multimodule-example/dokkatoo/parentProject/build.gradle.kts
+++ b/examples/multimodule-example/dokkatoo/parentProject/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   kotlin("jvm") version "1.7.20" apply false
-  id("dev.adamko.dokkatoo") version "1.2.1-SNAPSHOT"
+  id("dev.adamko.dokkatoo") version "1.3.0-SNAPSHOT"
 }
 
 dependencies {

--- a/examples/multimodule-example/dokkatoo/parentProject/childProjectA/build.gradle.kts
+++ b/examples/multimodule-example/dokkatoo/parentProject/childProjectA/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   kotlin("jvm")
-  id("dev.adamko.dokkatoo") version "1.2.1-SNAPSHOT"
+  id("dev.adamko.dokkatoo") version "1.3.0-SNAPSHOT"
 }
 
 dokkatoo {

--- a/examples/multimodule-example/dokkatoo/parentProject/childProjectB/build.gradle.kts
+++ b/examples/multimodule-example/dokkatoo/parentProject/childProjectB/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   kotlin("jvm")
-  id("dev.adamko.dokkatoo") version "1.2.1-SNAPSHOT"
+  id("dev.adamko.dokkatoo") version "1.3.0-SNAPSHOT"
 }
 
 dokkatoo {

--- a/examples/multiplatform-example/dokkatoo/build.gradle.kts
+++ b/examples/multiplatform-example/dokkatoo/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   kotlin("multiplatform") version "1.8.10"
-  id("dev.adamko.dokkatoo") version "1.2.1-SNAPSHOT"
+  id("dev.adamko.dokkatoo") version "1.3.0-SNAPSHOT"
 }
 
 group = "org.dokka.example"
@@ -23,7 +23,6 @@ kotlin {
 }
 
 dokkatoo {
-
   // Create a custom source set not known to the Kotlin Gradle Plugin
   dokkatooSourceSets.register("customSourceSet") {
     jdkVersion.set(9)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-kotlin = "1.7.20"
+kotlin = "1.7.10" # should match Gradle's embedded Kotlin version https://docs.gradle.org/current/userguide/compatibility.html#kotlin
 kotlin-dokka = "1.8.10"
 kotlinx-serialization = "1.5.0"
 

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
@@ -3,7 +3,7 @@ import dev.adamko.dokkatoo.dokka.plugins.DokkaHtmlPluginParameters
 
 plugins {
   kotlin("jvm") version "1.8.10"
-  id("dev.adamko.dokkatoo") version "1.2.1-SNAPSHOT"
+  id("dev.adamko.dokkatoo") version "1.3.0-SNAPSHOT"
 }
 
 version = "1.7.20-SNAPSHOT"

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -26,18 +26,22 @@ public abstract class dev/adamko/dokkatoo/DokkatooExtension : java/io/Serializab
 }
 
 public abstract interface class dev/adamko/dokkatoo/DokkatooExtension$Versions {
+	public static final field Companion Ldev/adamko/dokkatoo/DokkatooExtension$Versions$Companion;
+	public static final field VERSIONS_EXTENSION_NAME Ljava/lang/String;
 	public abstract fun getFreemarker ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJetbrainsDokka ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJetbrainsMarkdown ()Lorg/gradle/api/provider/Property;
+	public abstract fun getKotlinxCoroutines ()Lorg/gradle/api/provider/Property;
 	public abstract fun getKotlinxHtml ()Lorg/gradle/api/provider/Property;
+}
+
+public final class dev/adamko/dokkatoo/DokkatooExtension$Versions$Companion {
+	public static final field VERSIONS_EXTENSION_NAME Ljava/lang/String;
 }
 
 public abstract class dev/adamko/dokkatoo/DokkatooPlugin : org/gradle/api/Plugin {
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/Project;)V
-}
-
-public final class dev/adamko/dokkatoo/adapters/DokkatooKotlinAdapter$Companion {
 }
 
 public abstract class dev/adamko/dokkatoo/dokka/DokkaPublication : java/io/Serializable, org/gradle/api/Named {
@@ -218,6 +222,7 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIdSpec 
 	public final fun getScopeId ()Ljava/lang/String;
 	public abstract fun getSourceSetName ()Ljava/lang/String;
 	public abstract fun setSourceSetName (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIdSpec$Companion {
@@ -265,6 +270,7 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : 
 }
 
 public final class dev/adamko/dokkatoo/dokka/parameters/KotlinPlatform : java/lang/Enum {
+	public static final field AndroidJVM Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
 	public static final field Common Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;
 	public static final field Companion Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform$Companion;
 	public static final field JS Ldev/adamko/dokkatoo/dokka/parameters/KotlinPlatform;

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -160,7 +160,7 @@ constructor(
             name.endsWith("Main") -> name.substringBeforeLast("Main")
 
             // indeterminate source sets should be named by the Kotlin platform
-            else                  -> platform.key
+            else                  -> platform.displayName
           }
         }
       )

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -1,5 +1,6 @@
 package dev.adamko.dokkatoo
 
+import dev.adamko.dokkatoo.DokkatooExtension.Versions.Companion.VERSIONS_EXTENSION_NAME
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_BASE_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_CATEGORY_ATTRIBUTE
@@ -118,11 +119,12 @@ constructor(
       dokkatooModuleDirectory.convention(layout.buildDirectory.dir("dokka-module"))
       dokkatooConfigurationsDirectory.convention(layout.buildDirectory.dir("dokka-config"))
 
-      extensions.create<DokkatooExtension.Versions>("versions").apply {
+      extensions.create<DokkatooExtension.Versions>(VERSIONS_EXTENSION_NAME).apply {
         jetbrainsDokka.convention(DokkatooConstants.DOKKA_VERSION)
         jetbrainsMarkdown.convention("0.3.1")
         freemarker.convention("2.3.31")
         kotlinxHtml.convention("0.8.0")
+        kotlinxCoroutines.convention("1.6.4")
       }
     }
   }

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -177,8 +177,12 @@ constructor(
       noStdlibLink.convention(false)
 
       enableKotlinStdLibDocumentationLink.convention(true)
-      enableJdkDocumentationLink.convention(true)
-      enableAndroidDocumentationLink.convention(false)
+      enableJdkDocumentationLink.convention(
+        analysisPlatform.map { it == KotlinPlatform.JVM || it == KotlinPlatform.AndroidJVM }
+      )
+      enableAndroidDocumentationLink.convention(
+        analysisPlatform.map { it == KotlinPlatform.AndroidJVM }
+      )
 
       reportUndocumented.convention(false)
       skipDeprecated.convention(false)

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -177,9 +177,7 @@ constructor(
       noStdlibLink.convention(false)
 
       enableKotlinStdLibDocumentationLink.convention(true)
-      enableJdkDocumentationLink.convention(
-        analysisPlatform.map { it == KotlinPlatform.JVM || it == KotlinPlatform.AndroidJVM }
-      )
+      enableJdkDocumentationLink.convention(true)
       enableAndroidDocumentationLink.convention(
         analysisPlatform.map { it == KotlinPlatform.AndroidJVM }
       )

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
@@ -104,5 +104,10 @@ constructor(
     val jetbrainsMarkdown: Property<String>
     val freemarker: Property<String>
     val kotlinxHtml: Property<String>
+    val kotlinxCoroutines: Property<String>
+
+    companion object {
+      const val VERSIONS_EXTENSION_NAME = "versions"
+    }
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooAndroidAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooAndroidAdapter.kt
@@ -1,0 +1,38 @@
+package dev.adamko.dokkatoo.adapters
+
+import dev.adamko.dokkatoo.DokkatooBasePlugin
+import dev.adamko.dokkatoo.DokkatooExtension
+import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+import javax.inject.Inject
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.logging.Logging
+import org.gradle.kotlin.dsl.*
+
+@DokkatooInternalApi
+abstract class DokkatooAndroidAdapter @Inject constructor() : Plugin<Project> {
+  override fun apply(project: Project) {
+    logger.info("applied DokkatooAndroidAdapter to ${project.path}")
+
+    project.plugins.withType<DokkatooBasePlugin>().configureEach {
+      project.pluginManager.apply {
+        withPlugin("com.android.base") { configure(project) }
+        withPlugin("com.android.application") { configure(project) }
+        withPlugin("com.android.library") { configure(project) }
+      }
+    }
+  }
+
+  protected fun configure(project: Project) {
+    val dokkatooExtension = project.extensions.getByType<DokkatooExtension>()
+
+    dokkatooExtension.dokkatooSourceSets.configureEach {
+      enableAndroidDocumentationLink.set(true)
+    }
+  }
+
+  @DokkatooInternalApi
+  companion object {
+    private val logger = Logging.getLogger(DokkatooAndroidAdapter::class.java)
+  }
+}

--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooAndroidAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooAndroidAdapter.kt
@@ -1,16 +1,26 @@
 package dev.adamko.dokkatoo.adapters
 
+import com.android.build.gradle.internal.dependency.VariantDependencies
+import com.android.build.gradle.internal.publishing.AndroidArtifacts
 import dev.adamko.dokkatoo.DokkatooBasePlugin
 import dev.adamko.dokkatoo.DokkatooExtension
+import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+import dev.adamko.dokkatoo.internal.collectIncomingFiles
 import javax.inject.Inject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logging
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.*
 
 @DokkatooInternalApi
-abstract class DokkatooAndroidAdapter @Inject constructor() : Plugin<Project> {
+abstract class DokkatooAndroidAdapter @Inject constructor(
+  private val objects: ObjectFactory,
+) : Plugin<Project> {
+
   override fun apply(project: Project) {
     logger.info("applied DokkatooAndroidAdapter to ${project.path}")
 
@@ -27,7 +37,34 @@ abstract class DokkatooAndroidAdapter @Inject constructor() : Plugin<Project> {
     val dokkatooExtension = project.extensions.getByType<DokkatooExtension>()
 
     dokkatooExtension.dokkatooSourceSets.configureEach {
-      enableAndroidDocumentationLink.set(true)
+
+      val androidClasspath: Provider<FileCollection> =
+        analysisPlatform.map {
+          val compilationClasspath = objects.fileCollection()
+          if (it == KotlinPlatform.AndroidJVM) {
+
+            fun collectConfiguration(named: String) {
+              project.configurations.collectIncomingFiles(named, compilationClasspath)
+              // need to fetch JARs explicitly, because Android Gradle Plugin is weird
+              // and doesn't seem to register the attributes properly
+              @Suppress("UnstableApiUsage")
+              project.configurations.collectIncomingFiles(named, compilationClasspath) {
+                withVariantReselection()
+                attributes {
+                  attribute(AndroidArtifacts.ARTIFACT_TYPE, AndroidArtifacts.ArtifactType.JAR.type)
+                }
+                lenient(true)
+              }
+            }
+
+            // fetch android.jar
+            collectConfiguration(named = VariantDependencies.CONFIG_NAME_ANDROID_APIS)
+          }
+
+          compilationClasspath
+        }
+
+      classpath.from(androidClasspath)
     }
   }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
@@ -326,6 +326,7 @@ private data class KotlinCompilationDetails(
           // will trigger a bunch of Gradle warnings about "using file outputs without task dependencies",
           // so K/N compilations need to explicitly depend on the compilation tasks
           // UPDATE: actually I think is wrong, it's a bug with the K/N 'commonize for IDE' tasks
+          // see: https://github.com/Kotlin/dokka/issues/2977
           collectConfiguration(
             named = kotlinCompilation.defaultSourceSet.implementationMetadataConfigurationName,
 //          builtBy = kotlinCompilation.compileKotlinTaskProvider

--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooKotlinAdapter.kt
@@ -4,13 +4,16 @@ import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.LibraryVariant
 import dev.adamko.dokkatoo.DokkatooBasePlugin
 import dev.adamko.dokkatoo.DokkatooExtension
+import dev.adamko.dokkatoo.adapters.KotlinCompilationDetails.Companion.extractKotlinCompilationDetails
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetIdSpec
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetIdSpec.Companion.dokkaSourceSetIdSpec
+import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
 import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import dev.adamko.dokkatoo.internal.not
 import javax.inject.Inject
 import org.gradle.api.Named
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurationContainer
@@ -22,12 +25,17 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinSingleTargetExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 
 /**
@@ -63,124 +71,96 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
 
     val dokkatooExtension = project.extensions.getByType<DokkatooExtension>()
 
-    val allKotlinCompilationDetails = kotlinExtension.compilationDetails(objects, providers)
+    // first fetch the relevant properties of all KotlinCompilations
+    val allKotlinCompilationDetails: ListProperty<KotlinCompilationDetails> =
+      extractKotlinCompilationDetails(
+        kotlinProjectExtension = kotlinExtension,
+        objects = objects,
+        providers = providers,
+        configurations = project.configurations,
+      )
 
-    val sourceSetDetails = objects.domainObjectContainer(KotlinSourceSetDetails::class)
+    // second, fetch the relevant properties of the Kotlin source sets
+    val sourceSetDetails: NamedDomainObjectContainer<KotlinSourceSetDetails> =
+      KotlinSourceSetDetails.extractKotlinSourceSetDetails(
+        kotlinSourceSets = kotlinExtension.sourceSets,
+        sourceSetScopeDefault = dokkatooExtension.sourceSetScopeDefault,
+        allKotlinCompilationDetails = allKotlinCompilationDetails,
+        objects = objects,
+        providers = providers,
+      )
 
-    kotlinExtension.sourceSets.all kss@{
+    // for each Kotlin source set, register a Dokkatoo source set
+    registerDokkatooSourceSets(
+      dokkatooExtension = dokkatooExtension,
+      sourceSetDetails = sourceSetDetails,
+    )
+  }
 
-      val dependentSourceSets =
-        this@kss
-          .allDependentSourceSets()
-          .fold(objects.fileCollection()) { acc, src ->
-            acc.from(src.kotlin.sourceDirectories)
-          }
-
-      // TODO: Needs to respect filters.
-      //  We probably need to change from "sourceRoots" to support "sourceFiles"
-      //  https://github.com/Kotlin/dokka/issues/1215
-      val extantSourceDirectories =
-        this@kss.kotlin.sourceDirectories.filter { it.exists() }
-
-      // determine the source sets IDs of _other_ source sets that _this_ source depends on.
-      val dependentSourceSetIds =
-        dokkatooExtension.sourceSetScopeDefault.map { sourceSetScope ->
-          this@kss.dependsOn.map { dependedKss ->
-            objects.dokkaSourceSetIdSpec(sourceSetScope, dependedKss.name)
-          }
-        }
-
-      // find all compilation details that this source set needs
-      val compilations = allKotlinCompilationDetails.map { allCompilations ->
-        allCompilations.filter { compilation ->
-          this@kss.name in compilation.allKotlinSourceSetsNames
-        }
-      }
-
-      sourceSetDetails.register(name) {
-        this.dependentSourceSetIds.addAll(dependentSourceSetIds)
-        this.sourceSets.from(extantSourceDirectories)
-        this.dependentSourceSets.from(dependentSourceSets)
-        this.compilations.addAll(compilations)
-      }
-    }
-
+  /** Register a [DokkaSourceSetSpec] for each element in [sourceSetDetails] */
+  private fun registerDokkatooSourceSets(
+    dokkatooExtension: DokkatooExtension,
+    sourceSetDetails: NamedDomainObjectContainer<KotlinSourceSetDetails>,
+  ) {
     // proactively use 'all' so source sets will be available in users' build files if they use `named("...")`
     sourceSetDetails.all details@{
+      dokkatooExtension.dokkatooSourceSets.register(details = this@details)
+    }
+  }
 
-      val kssPlatform = compilations.map { values ->
-        values.map { it.kotlinPlatform }
-          .distinct()
-          .singleOrNull() ?: KotlinPlatform.Common
-      }
+  /** Register a single [DokkaSourceSetSpec] for [details] */
+  private fun NamedDomainObjectContainer<DokkaSourceSetSpec>.register(
+    details: KotlinSourceSetDetails
+  ) {
+    val kssPlatform = details.compilations.map { values: List<KotlinCompilationDetails> ->
+      values.map { it.kotlinPlatform }
+        .distinct()
+        .singleOrNull() ?: KotlinPlatform.Common
+    }
 
-      val sourceSetConfigurationNames = compilations.map { values ->
-        values.flatMap { it.configurationNames }
-      }
+    val kssClasspath = determineClasspath(details)
 
-      val kssClasspath = sourceSetConfigurationNames.map { names ->
-        getKSSClasspath(project.configurations, objects, names)
-      }
+    register(details.name) dss@{
+      // only set source-set specific properties, default values for the other properties
+      // (like displayName) are set in DokkatooBasePlugin
+      suppress.set(!details.isMainSourceSet())
+      sourceRoots.from(details.sourceDirectories)
+      //classpath.from(sourceDirectoriesOfDependents)
+      classpath.from(kssClasspath)
+      analysisPlatform.set(kssPlatform)
+      dependentSourceSets.addAllLater(details.dependentSourceSetIds)
+    }
+  }
 
-      dokkatooExtension.dokkatooSourceSets.register(this@details.name) {
-        // only set source-set specific properties, default values for the other properties
-        // (like displayName) are set in DokkatooBasePlugin
-        this.suppress.set(!isMainSourceSet())
-        this.sourceRoots.from(this@details.sourceSets)
-        this.classpath.from(kssClasspath)
-        this.analysisPlatform.set(kssPlatform)
-        this.dependentSourceSets.addAllLater(this@details.dependentSourceSetIds)
+  private fun determineClasspath(
+    details: KotlinSourceSetDetails
+  ): Provider<FileCollection> {
+
+    val classpath = objects.fileCollection()
+
+    return details.compilations.map { compilations: List<KotlinCompilationDetails> ->
+      if (compilations.isNotEmpty()) {
+        compilations.fold(classpath) { acc, details ->
+          acc.from(details.compilationClasspath)
+        }
+      } else {
+        classpath
+          .from(details.sourceDirectories)
+          .from(details.sourceDirectoriesOfDependents)
       }
     }
   }
 
+  @DokkatooInternalApi
   companion object {
 
     private val logger = Logging.getLogger(DokkatooKotlinAdapter::class.java)
 
-    private fun KotlinProjectExtension.compilationDetails(
-      objects: ObjectFactory,
-      providers: ProviderFactory,
-    ): ListProperty<KotlinCompilationDetails> {
-
-      val details = objects.listProperty<KotlinCompilationDetails>()
-
-      details.addAll(
-        providers.provider {
-          val allKotlinCompilations: Collection<KotlinCompilation<*>> = when (this) {
-            is KotlinMultiplatformExtension -> targets.flatMap { it.compilations }
-            is KotlinSingleTargetExtension<*> -> target.compilations
-            else -> emptyList()
-          }
-
-          allKotlinCompilations.map { compilation ->
-            KotlinCompilationDetails(
-              target = compilation.target.name,
-              kotlinPlatform = KotlinPlatform.fromString(compilation.platformType.name),
-              configurationNames = compilation.allConfigurationNames(),
-              allKotlinSourceSetsNames = compilation.allKotlinSourceSets.map { it.name },
-              mainCompilation = compilation.isMainCompilation(),
-            )
-          }
-        })
-
-      return details
-    }
-
-
-    /** Recursively get all [KotlinSourceSet]s that this source set depends on */
-    private tailrec fun KotlinSourceSet.allDependentSourceSets(
-      queue: ArrayDeque<KotlinSourceSet> = ArrayDeque<KotlinSourceSet>().apply { addAll(dependsOn) },
-      allDependents: List<KotlinSourceSet> = emptyList(),
-    ): List<KotlinSourceSet> {
-      val next = queue.removeFirstOrNull() ?: return allDependents
-      queue.addAll(next.dependsOn)
-      return next.allDependentSourceSets(queue, allDependents + next)
-    }
-
     private fun ExtensionContainer.findKotlinExtension(): KotlinProjectExtension? =
       try {
         findByType()
+        // fallback to trying to get the JVM extension
+        // (not sure why I did this... maybe to be compatible with really old versions?)
           ?: findByType<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension>()
       } catch (e: Throwable) {
         when (e) {
@@ -191,46 +171,6 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
           else                    -> throw e
         }
       }
-
-    private fun KotlinCompilation<*>.isMainCompilation(): Boolean {
-      return when (this) {
-        is KotlinJvmAndroidCompilation ->
-          androidVariant is LibraryVariant || androidVariant is ApplicationVariant
-
-        else                           ->
-          name == "main"
-      }
-    }
-
-    /**
-     * Get the [Configuration][org.gradle.api.artifacts.Configuration] names of all configurations
-     * used to build this [KotlinCompilation] and
-     * [its source sets][KotlinCompilation.kotlinSourceSets].
-     */
-    private fun KotlinCompilation<*>.allConfigurationNames(): Set<String> =
-      relatedConfigurationNames union kotlinSourceSets.flatMap { it.relatedConfigurationNames }
-
-    /** Get the classpath used to build and run a Kotlin Source Set */
-    private fun getKSSClasspath(
-      configurations: ConfigurationContainer,
-      objects: ObjectFactory,
-      kotlinSourceSetConfigurationNames: List<String>,
-    ): FileCollection {
-      return kotlinSourceSetConfigurationNames
-        .mapNotNull { kssConfName -> configurations.findByName(kssConfName) }
-        .filter { conf -> conf.isCanBeResolved }
-        .fold(objects.fileCollection()) { classpathCollector, conf ->
-          classpathCollector.from(
-            @Suppress("UnstableApiUsage")
-            conf
-              .incoming
-              .artifactView { lenient(true) }
-              .artifacts
-              .resolvedArtifacts
-              .map { artifacts -> artifacts.map { it.file } }
-          )
-        }
-    }
   }
 }
 
@@ -241,31 +181,293 @@ abstract class DokkatooKotlinAdapter @Inject constructor(
  * The compilation details may come from a multiplatform project ([KotlinMultiplatformExtension])
  * or a single-platform project ([KotlinSingleTargetExtension]).
  */
+@DokkatooInternalApi
 private data class KotlinCompilationDetails(
   val target: String,
   val kotlinPlatform: KotlinPlatform,
-  val configurationNames: Set<String>,
-  val allKotlinSourceSetsNames: List<String>,
+  val allKotlinSourceSetsNames: Set<String>,
   val mainCompilation: Boolean,
-)
+  //val compileDependencyFiles: FileCollection,
+  val dependentSourceSetNames: Set<String>,
+  val compilationClasspath: FileCollection,
+) {
+
+  @DokkatooInternalApi
+  companion object {
+
+    internal fun extractKotlinCompilationDetails(
+      kotlinProjectExtension: KotlinProjectExtension,
+      objects: ObjectFactory,
+      providers: ProviderFactory,
+      configurations: ConfigurationContainer,
+    ): ListProperty<KotlinCompilationDetails> {
+
+      val details = objects.listProperty<KotlinCompilationDetails>()
+
+      details.addAll(
+        providers.provider {
+          kotlinProjectExtension
+            .allKotlinCompilations()
+            .map { compilation ->
+              createCompilationDetails(
+                compilation = compilation,
+                objects = objects,
+//                providers = providers,
+                configurations = configurations,
+              )
+            }
+        })
+
+      return details
+    }
+
+    /** Create a single [KotlinCompilationDetails] for [compilation] */
+    private fun createCompilationDetails(
+      compilation: KotlinCompilation<*>,
+      objects: ObjectFactory,
+//      providers: ProviderFactory,
+      configurations: ConfigurationContainer,
+    ): KotlinCompilationDetails {
+      val allKotlinSourceSetsNames =
+        compilation.allKotlinSourceSets.map { it.name } + compilation.defaultSourceSet.name
+
+//      val compileDependencyFiles = objects.fileCollection()
+//      if (!compilation.target.isAndroidTarget()) {
+//        compileDependencyFiles.from(providers.provider { compilation.compileDependencyFiles })
+////              .from(providers.provider { compilation.runtimeDependencyFiles })
+//      }
+
+      val dependentSourceSetNames =
+        compilation.defaultSourceSet.dependsOn.map { it.name }
+
+      val compilationClasspath: FileCollection =
+        collectKotlinCompilationClasspath(
+          kotlinCompilation = compilation,
+          objects = objects,
+          configurations = configurations,
+        )
+
+      return KotlinCompilationDetails(
+        target = compilation.target.name,
+        kotlinPlatform = KotlinPlatform.fromString(compilation.platformType.name),
+        allKotlinSourceSetsNames = allKotlinSourceSetsNames.toSet(),
+        mainCompilation = compilation.isMainCompilation(),
+        //compileDependencyFiles = compileDependencyFiles,
+        dependentSourceSetNames = dependentSourceSetNames.toSet(),
+        compilationClasspath = compilationClasspath,
+      )
+    }
+
+    private fun KotlinProjectExtension.allKotlinCompilations(): Collection<KotlinCompilation<*>> =
+      when (this) {
+        is KotlinMultiplatformExtension -> targets.flatMap { it.compilations }
+        is KotlinSingleTargetExtension  -> target.compilations
+        else                            -> emptyList() // shouldn't happen?
+      }
+
+    /**
+     * Get the [Configuration][org.gradle.api.artifacts.Configuration] names of all configurations
+     * used to build this [KotlinCompilation] and
+     * [its source sets][KotlinCompilation.kotlinSourceSets].
+     */
+    private fun collectKotlinCompilationClasspath(
+      kotlinCompilation: KotlinCompilation<*>,
+      objects: ObjectFactory,
+      configurations: ConfigurationContainer,
+    ): FileCollection {
+
+      val compilationClasspath = objects.fileCollection()
+
+//      if (kotlinCompilation.target.isAndroidTarget()) {
+//        // Workaround for https://youtrack.jetbrains.com/issue/KT-33893
+//
+//      }
+
+      /**
+       * Aggregate the incoming files from a [Configuration][org.gradle.api.artifacts.Configuration]
+       * (with name [named]) into [compilationClasspath].
+       *
+       * Configurations that cannot be
+       * [resolved][org.gradle.api.artifacts.Configuration.isCanBeResolved]
+       * will be ignored.
+       */
+      fun collectConfiguration(named: String, builtBy: TaskProvider<*>? = null) {
+        val conf = configurations.findByName(named)
+        if (conf != null && conf.isCanBeResolved) {
+
+          val incomingFiles =
+            @Suppress("UnstableApiUsage")
+            conf
+              .incoming
+              .artifactView { lenient(true) }
+              .artifacts
+              .resolvedArtifacts
+              .map { artifacts -> artifacts.map { it.file } }
+
+          compilationClasspath.from(incomingFiles)
+
+          if (builtBy != null) {
+            compilationClasspath.builtBy(builtBy)
+          }
+        }
+      }
+
+      val standardConfigurations = mutableListOf<String>().apply {
+        addAll(kotlinCompilation.relatedConfigurationNames)
+        addAll(kotlinCompilation.kotlinSourceSets.flatMap { it.relatedConfigurationNames })
+      }.toSet()
+
+      standardConfigurations.forEach(::collectConfiguration)
+
+      if (!kotlinCompilation.target.isAndroidTarget()) {
+        if (kotlinCompilation is AbstractKotlinNativeCompilation) {
+          // K/N doesn't correctly set task dependencies, the configuration
+          // `defaultSourceSet.implementationMetadataConfigurationName`
+          // will trigger a bunch of Gradle warnings about "using file outputs without task dependencies",
+          // so K/N compilations need to explicitly depend on the compilation tasks
+          // UPDATE: actually I think is wrong, it's a bug with the K/N 'commonize for IDE' tasks
+          collectConfiguration(
+            named = kotlinCompilation.defaultSourceSet.implementationMetadataConfigurationName,
+//          builtBy = kotlinCompilation.compileKotlinTaskProvider
+          )
+        }
+      }
+
+      return compilationClasspath
+    }
+
+    private fun KotlinCompilation<*>.isMainCompilation(): Boolean {
+      return when (this) {
+        is KotlinJvmAndroidCompilation ->
+          androidVariant is LibraryVariant || androidVariant is ApplicationVariant
+
+        else                           ->
+          name == KotlinCompilation.Companion.MAIN_COMPILATION_NAME//  "main"
+      }
+    }
+
+    private fun KotlinTarget.isAndroidTarget(): Boolean =
+      platformType == KotlinPlatformType.androidJvm
+  }
+}
 
 
 /**
  * Store the details of all [KotlinSourceSet]s in a configuration cache compatible way.
+ *
+ * @param[named] Should be [KotlinSourceSet.getName]
  */
+@DokkatooInternalApi
 private abstract class KotlinSourceSetDetails @Inject constructor(
   private val named: String,
 ) : Named {
 
-  abstract val dependentSourceSetIds: ListProperty<DokkaSourceSetIdSpec>
-  abstract val sourceSets: ConfigurableFileCollection
-  abstract val dependentSourceSets: ConfigurableFileCollection
+  /** Direct source sets that this source set depends on */
+  abstract val dependentSourceSetIds: SetProperty<DokkaSourceSetIdSpec>
+  abstract val sourceDirectories: ConfigurableFileCollection
+  /** _All_ source directories from any (recursively) dependant source set */
+  abstract val sourceDirectoriesOfDependents: ConfigurableFileCollection
+  /** The specific compilations used to build this source set */
   abstract val compilations: ListProperty<KotlinCompilationDetails>
 
+  /** Estimate if this Kotlin source set are 'main' sources (as opposed to 'test' sources). */
   fun isMainSourceSet(): Provider<Boolean> =
     compilations.map { values ->
       values.isEmpty() || values.any { it.mainCompilation }
     }
 
   override fun getName(): String = named
+
+  @DokkatooInternalApi
+  companion object {
+
+    internal fun extractKotlinSourceSetDetails(
+      kotlinSourceSets: NamedDomainObjectContainer<KotlinSourceSet>,
+      sourceSetScopeDefault: Provider<String>,
+      allKotlinCompilationDetails: ListProperty<KotlinCompilationDetails>,
+      objects: ObjectFactory,
+      providers: ProviderFactory,
+    ): NamedDomainObjectContainer<KotlinSourceSetDetails> {
+
+      val sourceSetDetails = objects.domainObjectContainer(KotlinSourceSetDetails::class)
+
+      kotlinSourceSets.configureEach kss@{
+        sourceSetDetails.register(
+          kotlinSourceSet = this,
+          allKotlinCompilationDetails = allKotlinCompilationDetails,
+          sourceSetScopeDefault = sourceSetScopeDefault,
+          providers = providers,
+          objects = objects,
+        )
+      }
+
+      return sourceSetDetails
+    }
+
+    private fun NamedDomainObjectContainer<KotlinSourceSetDetails>.register(
+      kotlinSourceSet: KotlinSourceSet,
+      allKotlinCompilationDetails: ListProperty<KotlinCompilationDetails>,
+      sourceSetScopeDefault: Provider<String>,
+      providers: ProviderFactory,
+      objects: ObjectFactory,
+    ) {
+
+      // TODO: Needs to respect filters.
+      //  We probably need to change from "sourceRoots" to support "sourceFiles"
+      //  https://github.com/Kotlin/dokka/issues/1215
+      val extantSourceDirectories = providers.provider {
+        kotlinSourceSet.kotlin.sourceDirectories.filter { it.exists() }
+      }
+
+      val compilations = allKotlinCompilationDetails.map { allCompilations ->
+        allCompilations.filter { compilation ->
+          kotlinSourceSet.name in compilation.allKotlinSourceSetsNames
+        }
+      }
+
+      // determine the source sets IDs of _other_ source sets that _this_ source depends on.
+      val dependentSourceSets = providers.provider { kotlinSourceSet.dependsOn }
+      val dependentSourceSetIds =
+        providers.zip(
+          dependentSourceSets,
+          sourceSetScopeDefault,
+        ) { sourceSets, sourceSetScope ->
+          sourceSets.map { dependedKss ->
+            objects.dokkaSourceSetIdSpec(sourceSetScope, dependedKss.name)
+          }
+        }
+
+      val sourceDirectoriesOfDependents = providers.provider {
+        kotlinSourceSet
+          .allDependentSourceSets()
+          .fold(objects.fileCollection()) { acc, sourceSet ->
+            acc.from(sourceSet.kotlin.sourceDirectories)
+          }
+      }
+
+      register(kotlinSourceSet.name) {
+        this.dependentSourceSetIds.addAll(dependentSourceSetIds)
+        this.sourceDirectories.from(extantSourceDirectories)
+        this.sourceDirectoriesOfDependents.from(sourceDirectoriesOfDependents)
+        this.compilations.addAll(compilations)
+      }
+    }
+
+    /**
+     * Return a list containing _all_ source sets that this source set depends on,
+     * searching recursively.
+     *
+     * @see KotlinSourceSet.dependsOn
+     */
+    private tailrec fun KotlinSourceSet.allDependentSourceSets(
+      queue: Set<KotlinSourceSet> = dependsOn.toSet(),
+      allDependents: List<KotlinSourceSet> = emptyList(),
+    ): List<KotlinSourceSet> {
+      val next = queue.firstOrNull() ?: return allDependents
+      return next.allDependentSourceSets(
+        queue = (queue - next) union next.dependsOn,
+        allDependents = allDependents + next,
+      )
+    }
+  }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
@@ -64,7 +64,8 @@ constructor(
     get() = outputDir.map { it.asFile.invariantSeparatorsPath }
 
   @get:Internal
-  // marked as Internal because this task does not use the directory contents, only the location
+  // Marked as Internal because this task does not use the directory contents, only the location.
+  // Note that `cacheRoot` is not used by Dokka, and will probably be deprecated.
   abstract val cacheRoot: DirectoryProperty
 
   /**

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetIdSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetIdSpec.kt
@@ -35,7 +35,9 @@ constructor(
     DokkaParametersKxs.SourceSetIdKxs(scopeId, sourceSetName)
 
   @Internal
-  override fun getName(): String = scopeId
+  override fun getName(): String = "$scopeId/$sourceSetName"
+
+  override fun toString(): String = "DokkaSourceSetIdSpec($name)"
 
   companion object {
 
@@ -48,6 +50,5 @@ constructor(
       newInstance<DokkaSourceSetIdSpec>(scopeId).apply {
         this.sourceSetName = sourceSetName
       }
-
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/KotlinPlatform.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/KotlinPlatform.kt
@@ -7,31 +7,40 @@ import org.jetbrains.dokka.Platform
  * The Kotlin
  *
  * @see org.jetbrains.dokka.Platform
+ * @param[displayName] The display name, eventually used in the rendered Dokka publication.
  */
-enum class KotlinPlatform {
-  JVM,
-  JS,
-  WASM,
-  Native,
-  Common,
+enum class KotlinPlatform(
+  internal val displayName: String
+) {
+  JVM("jvm"),
+  AndroidJVM("androidJvm"),
+  JS("js"),
+  WASM("wasm"),
+  Native("native"),
+  Common("common"),
   ;
 
+  @Deprecated("Unused", ReplaceWith("name.toLowerCase()"))
+  @Suppress("unused")
   val key: String = name.toLowerCase()
 
   companion object {
-    internal val entries: Set<KotlinPlatform> = values().toSet()
+    internal val values: Set<KotlinPlatform> = values().toSet()
 
     val DEFAULT: KotlinPlatform = JVM
 
     fun fromString(key: String): KotlinPlatform {
+      val keyMatch = values.firstOrNull {
+        it.name.equals(key, ignoreCase = true) || it.displayName.equals(key, ignoreCase = true)
+      }
+      if (keyMatch != null) {
+        return keyMatch
+      }
 
       return when (key.toLowerCase()) {
-        JVM.key, "androidjvm", "android" -> JVM
-        JS.key                           -> JS
-        WASM.key                         -> WASM
-        Native.key                       -> Native
-        Common.key, "metadata"           -> Common
-        else                             -> error("Unrecognized platform: $key")
+        "android"  -> AndroidJVM
+        "metadata" -> Common
+        else       -> error("Unrecognized platform: $key")
       }
     }
 
@@ -39,11 +48,11 @@ enum class KotlinPlatform {
     internal val KotlinPlatform.dokkaType: Platform
       get() =
         when (this) {
-          JVM    -> Platform.jvm
-          JS     -> Platform.js
-          WASM   -> Platform.wasm
-          Native -> Platform.native
-          Common -> Platform.common
+          AndroidJVM, JVM -> Platform.jvm
+          JS              -> Platform.js
+          WASM            -> Platform.wasm
+          Native          -> Platform.native
+          Common          -> Platform.common
         }
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/KotlinPlatform.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/KotlinPlatform.kt
@@ -12,12 +12,12 @@ import org.jetbrains.dokka.Platform
 enum class KotlinPlatform(
   internal val displayName: String
 ) {
-  JVM("jvm"),
   AndroidJVM("androidJvm"),
-  JS("js"),
-  WASM("wasm"),
-  Native("native"),
   Common("common"),
+  JS("js"),
+  JVM("jvm"),
+  Native("native"),
+  WASM("wasm"),
   ;
 
   @Deprecated("Unused", ReplaceWith("name.toLowerCase()"))

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -2,6 +2,7 @@ package dev.adamko.dokkatoo.formats
 
 import dev.adamko.dokkatoo.DokkatooBasePlugin
 import dev.adamko.dokkatoo.DokkatooExtension
+import dev.adamko.dokkatoo.adapters.DokkatooAndroidAdapter
 import dev.adamko.dokkatoo.adapters.DokkatooJavaAdapter
 import dev.adamko.dokkatoo.adapters.DokkatooKotlinAdapter
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes
@@ -68,6 +69,7 @@ abstract class DokkatooFormatPlugin(
     // apply the plugin that will autoconfigure Dokkatoo to use the sources of a Kotlin project
     target.pluginManager.apply(type = DokkatooKotlinAdapter::class)
     target.pluginManager.apply(type = DokkatooJavaAdapter::class)
+    target.pluginManager.apply(type = DokkatooAndroidAdapter::class)
 
     target.plugins.withType<DokkatooBasePlugin>().configureEach {
       val dokkatooExtension = target.extensions.getByType(DokkatooExtension::class)

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -193,8 +193,9 @@ abstract class DokkatooFormatPlugin(
         dokkaPlugin("org.freemarker:freemarker" version freemarker)
 
         dokkaGenerator(dokka("dokka-core"))
-        // TODO why does this need a -jvm suffix?
+        // TODO why does org.jetbrains:markdown need a -jvm suffix?
         dokkaGenerator("org.jetbrains:markdown-jvm" version jetbrainsMarkdown)
+        dokkaGenerator("org.jetbrains.kotlinx:kotlinx-coroutines-core" version kotlinxCoroutines)
       }
     }
   }

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
@@ -4,9 +4,12 @@ import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.ArtifactView
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskProvider
@@ -72,3 +75,44 @@ internal fun <T> NamedDomainObjectContainer<T>.maybeCreate(
   name: String,
   configure: T.() -> Unit,
 ): T = maybeCreate(name).apply(configure)
+
+
+/**
+ * Aggregate the incoming files from a [Configuration]
+ * (with name [named]) into [collector].
+ *
+ * Configurations that cannot be
+ * [resolved][org.gradle.api.artifacts.Configuration.isCanBeResolved]
+ * will be ignored.
+ *
+ * @param[builtBy] An optional [TaskProvider], used to set [ConfigurableFileCollection.builtBy].
+ * This should not typically be used, and is only necessary in rare cases where a Gradle Plugin is
+ * misconfigured.
+ */
+internal fun ConfigurationContainer.collectIncomingFiles(
+  named: String,
+  collector: ConfigurableFileCollection,
+  builtBy: TaskProvider<*>? = null,
+  artifactViewConfiguration: ArtifactView.ViewConfiguration.() -> Unit = {
+    // ignore failures: it's usually okay if fetching files is best-effort because
+    // maybe Dokka doesn't need _all_ dependencies
+    lenient(true)
+  },
+) {
+  val conf = findByName(named)
+  if (conf != null && conf.isCanBeResolved) {
+
+    val incomingFiles =
+      conf
+        .incoming
+        .artifactView(artifactViewConfiguration)
+        .artifacts
+        .artifactFiles
+
+    collector.from(incomingFiles)
+
+    if (builtBy != null) {
+      collector.builtBy(builtBy)
+    }
+  }
+}

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooPrepareParametersTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooPrepareParametersTask.kt
@@ -58,6 +58,7 @@ constructor(
   abstract val dokkaModuleFiles: ConfigurableFileCollection
 
   @get:LocalState
+  // cacheRoot is not used by Dokka, and will probably be deprecated
   abstract val cacheRoot: DirectoryProperty
 
   @get:Input

--- a/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/KotlinPlatformTest.kt
+++ b/modules/dokkatoo-plugin/src/test/kotlin/dokka/parameters/KotlinPlatformTest.kt
@@ -16,7 +16,7 @@ class KotlinPlatformTest : FunSpec({
   test("Dokka platform should have equivalent KotlinPlatform") {
 
     Platform.values().shouldForAll { dokkaPlatform ->
-      dokkaPlatform shouldBeIn KotlinPlatform.entries.map { it.dokkaType }
+      dokkaPlatform shouldBeIn KotlinPlatform.values.map { it.dokkaType }
     }
   }
 

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/samWithReceiverWorkarounds.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/samWithReceiverWorkarounds.kt
@@ -2,11 +2,13 @@
 
 package dev.adamko.dokkatoo.utils
 
-import dev.adamko.dokkatoo.dokka.parameters.DokkaExternalDocumentationLinkSpec
 import dev.adamko.dokkatoo.dokka.parameters.DokkaPackageOptionsSpec
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceLinkSpec
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
-import org.gradle.api.*
+import org.gradle.api.DomainObjectCollection
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectProvider
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencySet
 
@@ -67,10 +69,6 @@ fun <T> NamedDomainObjectContainer<T>.register_(
 ): NamedDomainObjectProvider<T> =
   register(name, configure)
 
-
-fun DokkaSourceSetSpec.externalDocumentationLink_(
-  action: DokkaExternalDocumentationLinkSpec.() -> Unit
-) = externalDocumentationLink(action)
 
 fun DokkaSourceSetSpec.sourceLink_(
   action: DokkaSourceLinkSpec.() -> Unit


### PR DESCRIPTION
fixes several issues discovered while investigating #57 

* Breaking change: add AndroidJVM target (technically adding an enum value is a breaking change, but it's unlikely anyone is using the enum as-is)
* Deprecate `KotlinPlatformTarget.key` - replaced with an internal val that better matches DGP current display name of targets.
* Refactor `DokkatooKotlinAdapter` to better match existing DGP code
* Create `DokkatooAndroidAdapter` to automatically enable the Android documentation link
* Add kotlinx-coroutines dependency for DokkaGenerator (otherwise `finalizeCoroutines` fails, as the method isn't present)
* fix `getName()` of `DokkaSourceSetIdSpec` - it now includes the source set name
* fetch `android.jar` via the `androidApis` configuration
* fetch `JAVA_RUNTIME` files via configurations, because otherwise the Android-based configurations don't seem to work.