### PR TITLE
Fix DokkaGenerator not clearing deleted files

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -13,6 +13,7 @@ import dev.adamko.dokkatoo.tasks.DokkatooGenerateTask
 import dev.adamko.dokkatoo.tasks.DokkatooPrepareModuleDescriptorTask
 import dev.adamko.dokkatoo.tasks.DokkatooPrepareParametersTask
 import dev.adamko.dokkatoo.tasks.DokkatooTask
+import java.io.File
 import java.net.URL
 import javax.inject.Inject
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -22,6 +23,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
@@ -75,7 +77,7 @@ constructor(
     target.tasks.withType<DokkatooGenerateTask>().configureEach {
       cacheDirectory.convention(dokkatooExtension.dokkatooCacheDirectory)
       workerDebugEnabled.convention(false)
-      workerLogFile.set(temporaryDir.resolve("dokka-worker.log"))
+      workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
       // increase memory - DokkaGenerator is hungry https://github.com/Kotlin/dokka/issues/1405
       workerMinHeapSize.convention("512m")
       workerMaxHeapSize.convention("1g")
@@ -258,6 +260,10 @@ constructor(
       dependsOn(withType<DokkatooGenerateTask>())
     }
   }
+
+  // workaround for https://github.com/gradle/gradle/issues/23708
+  private fun RegularFileProperty.convention(file: File): RegularFileProperty =
+    convention(objects.fileProperty().fileValue(file))
 
   companion object {
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/workers/DokkaGeneratorWorker.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/workers/DokkaGeneratorWorker.kt
@@ -26,9 +26,19 @@ abstract class DokkaGeneratorWorker : WorkAction<DokkaGeneratorWorker.Parameters
   }
 
   override fun execute() {
-    LoggerAdapter(parameters.logFile.get().asFile).use { logger ->
+    val dokkaParameters = parameters.dokkaParameters.get()
 
-      val dokkaParameters = parameters.dokkaParameters.get()
+    // Dokka Generator doesn't clean up old files, so we need to manually clean the output directory
+    dokkaParameters.outputDir.deleteRecursively()
+    dokkaParameters.outputDir.mkdirs()
+
+    executeDokkaGenerator(dokkaParameters)
+  }
+
+  private fun executeDokkaGenerator(
+    dokkaParameters: DokkaConfiguration
+  ) {
+    LoggerAdapter(parameters.logFile.get().asFile).use { logger ->
       logger.progress("Executing DokkaGeneratorWorker with dokkaParameters: $dokkaParameters")
 
       val generator = DokkaGenerator(dokkaParameters, logger)

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -45,8 +45,6 @@ class GradleProjectTest(
     val integrationTestProjectsDir: Path by systemProperty(Paths::get)
     /** Dokka Source directory that contains example Gradle projects */
     val exampleProjectsDir: Path by systemProperty(Paths::get)
-
-    val GRADLE_RO_DEP_CACHE: String? by optionalEnvironmentVariable()
   }
 }
 

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -319,12 +319,17 @@ class MultiModuleFunctionalTest : FunSpec({
               )
               .forwardOutput()
               .build {
-                test("expect the generated HTML file is deleted") {
-                  val helloAgainIndexHtml = project.projectDir.resolve(
-                    "build/dokka/html/subproject-hello/com.project.hello/-hello-again/index.html"
-                  )
 
+                test("expect HelloAgain HTML file is now deleted") {
                   helloAgainIndexHtml.shouldNotExist()
+
+                  project.dir("build/dokka/html/") {
+                    projectDir.toTreeString().shouldNotContainAnyOf(
+                      "hello-again",
+                      "-hello-again/",
+                      "-hello-again.html",
+                    )
+                  }
                 }
               }
           }


### PR DESCRIPTION
If I have a multi-module project and I run `:dokkatooGeneratePublicationHtml` then Dokkatoo will generate an HTML publication.

However, if I delete a `Foo.kt` file in one of the subprojects and re-run `:dokkatooGeneratePublicationHtml` then DokkaGenerator will not delete the `Foo.html` file in the HTML publication.

This PR will manually clean up the output directory before running DokkaGenerator to resolve this problem. 

This PR also includes some minor fixes and tidy-ups.