### PR TITLE
Feat/improve plugin DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ dokkatoo {
     }
   }
 
-  pluginsConfiguration.named<DokkaHtmlPluginParameters>("html") {
+  pluginsConfiguration.html {
     customStyleSheets.from(
       "./customResources/logo-styles.css",
       "./customResources/custom-style-to-add.css",

--- a/examples/custom-format-example/dokkatoo/build.gradle.kts
+++ b/examples/custom-format-example/dokkatoo/build.gradle.kts
@@ -1,5 +1,3 @@
-import dev.adamko.dokkatoo.dokka.plugins.DokkaHtmlPluginParameters
-
 plugins {
   kotlin("jvm") version "1.8.10"
   id("dev.adamko.dokkatoo") version "1.4.0-SNAPSHOT"
@@ -7,7 +5,7 @@ plugins {
 
 dokkatoo {
   moduleName.set("customFormat-example")
-  pluginsConfiguration.named<DokkaHtmlPluginParameters>("html") {
+  pluginsConfiguration.html {
     // Custom format adds a custom logo
     customStyleSheets.from("logo-styles.css")
     customAssets.from("ktor-logo.png")

--- a/examples/custom-format-example/dokkatoo/settings.gradle.kts
+++ b/examples/custom-format-example/dokkatoo/settings.gradle.kts
@@ -2,8 +2,8 @@ rootProject.name = "custom-format-example"
 
 pluginManagement {
   repositories {
-    gradlePluginPortal()
     mavenCentral()
+    gradlePluginPortal()
     maven(providers.gradleProperty("testMavenRepo"))
   }
 }

--- a/examples/gradle-example/dokkatoo/build.gradle.kts
+++ b/examples/gradle-example/dokkatoo/build.gradle.kts
@@ -7,7 +7,7 @@ dokkatoo {
   // used as project name in the header
   moduleName.set("Dokka Gradle Example")
 
-  dokkatooSourceSets.named("main") {
+  dokkatooSourceSets.main {
 
     // contains descriptions for the module and the packages
     includes.from("Module.md")

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -17,15 +17,16 @@ public abstract class dev/adamko/dokkatoo/DokkatooExtension : java/io/Serializab
 	public abstract fun getDokkatooModuleDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getDokkatooPublicationDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getDokkatooPublications ()Lorg/gradle/api/NamedDomainObjectContainer;
-	public abstract fun getDokkatooSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
+	public final fun getDokkatooSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
 	public abstract fun getModuleName ()Lorg/gradle/api/provider/Property;
 	public abstract fun getModulePath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getModuleVersion ()Lorg/gradle/api/provider/Property;
 	public final fun getPluginsConfiguration ()Lorg/gradle/api/ExtensiblePolymorphicDomainObjectContainer;
 	public abstract fun getSourceSetScopeDefault ()Lorg/gradle/api/provider/Property;
+	public final fun getVersions ()Ldev/adamko/dokkatoo/DokkatooExtension$Versions;
 }
 
-public abstract interface class dev/adamko/dokkatoo/DokkatooExtension$Versions {
+public abstract interface class dev/adamko/dokkatoo/DokkatooExtension$Versions : org/gradle/api/plugins/ExtensionAware {
 	public static final field Companion Ldev/adamko/dokkatoo/DokkatooExtension$Versions$Companion;
 	public static final field VERSIONS_EXTENSION_NAME Ljava/lang/String;
 	public abstract fun getFreemarker ()Lorg/gradle/api/provider/Property;
@@ -44,7 +45,7 @@ public abstract class dev/adamko/dokkatoo/DokkatooPlugin : org/gradle/api/Plugin
 	public fun apply (Lorg/gradle/api/Project;)V
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/DokkaPublication : java/io/Serializable, org/gradle/api/Named {
+public abstract class dev/adamko/dokkatoo/dokka/DokkaPublication : java/io/Serializable, org/gradle/api/Named, org/gradle/api/plugins/ExtensionAware {
 	public abstract fun getCacheRoot ()Lorg/gradle/api/file/DirectoryProperty;
 	protected final fun getCacheRootPath ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getDelayTemplateSubstitution ()Lorg/gradle/api/provider/Property;
@@ -228,7 +229,7 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIdSpec 
 public final class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetIdSpec$Companion {
 }
 
-public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, dev/adamko/dokkatoo/dokka/parameters/HasConfigurableVisibilityModifiers, java/io/Serializable, org/gradle/api/Named {
+public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : dev/adamko/dokkatoo/dokka/parameters/DokkaParameterBuilder, dev/adamko/dokkatoo/dokka/parameters/HasConfigurableVisibilityModifiers, java/io/Serializable, org/gradle/api/Named, org/gradle/api/plugins/ExtensionAware {
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun externalDocumentationLink (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun externalDocumentationLink (Ljava/net/URL;Ljava/net/URL;)V
@@ -238,13 +239,13 @@ public abstract class dev/adamko/dokkatoo/dokka/parameters/DokkaSourceSetSpec : 
 	public abstract fun getAnalysisPlatform ()Lorg/gradle/api/provider/Property;
 	public abstract fun getApiVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getDependentSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
+	public final fun getDependentSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
 	public abstract fun getDisplayName ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDocumentedVisibilities ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getEnableAndroidDocumentationLink ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableJdkDocumentationLink ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableKotlinStdLibDocumentationLink ()Lorg/gradle/api/provider/Property;
-	public abstract fun getExternalDocumentationLinks ()Lorg/gradle/api/NamedDomainObjectContainer;
+	public final fun getExternalDocumentationLinks ()Lorg/gradle/api/NamedDomainObjectContainer;
 	public abstract fun getIncludes ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getJdkVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
@@ -497,10 +498,11 @@ public abstract class dev/adamko/dokkatoo/tasks/DokkatooPrepareParametersTask : 
 }
 
 public abstract class dev/adamko/dokkatoo/tasks/DokkatooTask : org/gradle/api/DefaultTask {
+	public abstract fun getObjects ()Lorg/gradle/api/model/ObjectFactory;
 }
 
 public abstract class dev/adamko/dokkatoo/tasks/DokkatooTask$WithSourceSets : dev/adamko/dokkatoo/tasks/DokkatooTask {
 	public final fun addAllDokkaSourceSets (Lorg/gradle/api/provider/Provider;)V
-	public abstract fun getDokkaSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
+	public final fun getDokkaSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
 }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -1,6 +1,5 @@
 package dev.adamko.dokkatoo
 
-import dev.adamko.dokkatoo.DokkatooExtension.Versions.Companion.VERSIONS_EXTENSION_NAME
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_BASE_ATTRIBUTE
 import dev.adamko.dokkatoo.distibutions.DokkatooConfigurationAttributes.Companion.DOKKATOO_CATEGORY_ATTRIBUTE
@@ -111,7 +110,7 @@ constructor(
   }
 
   private fun createExtension(project: Project): DokkatooExtension {
-    return project.extensions.create<DokkatooExtension>(EXTENSION_NAME).apply {
+    val dokkatooExtension = project.extensions.create<DokkatooExtension>(EXTENSION_NAME).apply {
       moduleName.convention(providers.provider { project.name })
       moduleVersion.convention(providers.provider { project.version.toString() })
       modulePath.convention(project.pathAsFilePath())
@@ -120,15 +119,17 @@ constructor(
       dokkatooPublicationDirectory.convention(layout.buildDirectory.dir("dokka"))
       dokkatooModuleDirectory.convention(layout.buildDirectory.dir("dokka-module"))
       dokkatooConfigurationsDirectory.convention(layout.buildDirectory.dir("dokka-config"))
-
-      extensions.create<DokkatooExtension.Versions>(VERSIONS_EXTENSION_NAME).apply {
-        jetbrainsDokka.convention(DokkatooConstants.DOKKA_VERSION)
-        jetbrainsMarkdown.convention("0.3.1")
-        freemarker.convention("2.3.31")
-        kotlinxHtml.convention("0.8.0")
-        kotlinxCoroutines.convention("1.6.4")
-      }
     }
+
+    dokkatooExtension.versions {
+      jetbrainsDokka.convention(DokkatooConstants.DOKKA_VERSION)
+      jetbrainsMarkdown.convention("0.3.1")
+      freemarker.convention("2.3.31")
+      kotlinxHtml.convention("0.8.0")
+      kotlinxCoroutines.convention("1.6.4")
+    }
+
+    return dokkatooExtension
   }
 
   /** Set defaults in all [DokkatooExtension.dokkatooPublications]s */

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
@@ -2,11 +2,13 @@ package dev.adamko.dokkatoo.dokka
 
 import dev.adamko.dokkatoo.internal.DokkaPluginParametersContainer
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+import dev.adamko.dokkatoo.internal.adding
 import java.io.Serializable
 import javax.inject.Inject
 import org.gradle.api.Named
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
@@ -32,9 +34,13 @@ constructor(
    * Configurations for Dokka Generator Plugins. Must be provided from
    * [dev.adamko.dokkatoo.DokkatooExtension.pluginsConfiguration].
    */
+  private val _pluginsConfiguration: DokkaPluginParametersContainer,
+) : Named, Serializable, ExtensionAware {
+
+  /** Configurations for Dokka Generator Plugins. */
   @get:Nested
-  val pluginsConfiguration: DokkaPluginParametersContainer,
-) : Named, Serializable {
+  val pluginsConfiguration: DokkaPluginParametersContainer =
+    extensions.adding("pluginsConfiguration") { _pluginsConfiguration }
 
   @Internal
   override fun getName(): String = formatName

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaSourceSetSpec.kt
@@ -3,8 +3,7 @@ package dev.adamko.dokkatoo.dokka.parameters
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetIdSpec.Companion.dokkaSourceSetIdSpec
 import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform.Companion.dokkaType
 import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier.Companion.dokkaType
-import dev.adamko.dokkatoo.internal.DokkatooInternalApi
-import dev.adamko.dokkatoo.internal.mapToSet
+import dev.adamko.dokkatoo.internal.*
 import java.io.Serializable
 import java.net.URL
 import javax.inject.Inject
@@ -12,6 +11,7 @@ import org.gradle.api.*
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.model.ReplacedBy
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.*
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.*
@@ -49,7 +49,8 @@ constructor(
   DokkaParameterBuilder<DokkaParametersKxs.DokkaSourceSetKxs>,
   HasConfigurableVisibilityModifiers,
   Named,
-  Serializable {
+  Serializable,
+  ExtensionAware {
 
   @Internal // will be tracked by sourceSetId
   override fun getName(): String = name
@@ -153,7 +154,10 @@ constructor(
    * By default, the values are deduced from information provided by the Kotlin Gradle plugin.
    */
   @get:Nested
-  abstract val dependentSourceSets: NamedDomainObjectContainer<DokkaSourceSetIdSpec>
+  val dependentSourceSets: NamedDomainObjectContainer<DokkaSourceSetIdSpec> =
+    extensions.adding("dependentSourceSets") {
+      objects.domainObjectContainer()
+    }
 
   /**
    * Classpath for analysis and interactive samples.
@@ -222,7 +226,8 @@ constructor(
    * Prefer using [externalDocumentationLink] action/closure for adding links.
    */
   @get:Nested
-  abstract val externalDocumentationLinks: NamedDomainObjectContainer<DokkaExternalDocumentationLinkSpec>
+  val externalDocumentationLinks: NamedDomainObjectContainer<DokkaExternalDocumentationLinkSpec> =
+    extensions.adding("externalDocumentationLinks") { objects.domainObjectContainer() }
 
   /**
    * Platform to be used for setting up code analysis and samples.

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -149,7 +149,7 @@ abstract class DokkatooFormatPlugin(
 
     var addDefaultDokkaDependencies = true
 
-    /** Create a [Dependency] for  */
+    /** Create a [Dependency] for a Dokka module */
     fun DependencyHandler.dokka(module: String): Provider<Dependency> =
       dokkatooExtension.versions.jetbrainsDokka.map { version -> create("org.jetbrains.dokka:$module:$version") }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooHtmlPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooHtmlPlugin.kt
@@ -12,7 +12,8 @@ abstract class DokkatooHtmlPlugin
 constructor() : DokkatooFormatPlugin(formatName = "html") {
 
   override fun DokkatooFormatPluginContext.configure() {
-    configureDokkaHtmlPlugins()
+    registerDokkaBasePluginConfiguration()
+    registerDokkaVersioningPlugin()
 
     dokkatooTasks.generatePublication.configure {
       doLast {
@@ -23,20 +24,24 @@ constructor() : DokkatooFormatPlugin(formatName = "html") {
     }
   }
 
-  private fun DokkatooFormatPluginContext.configureDokkaHtmlPlugins() {
+  private fun DokkatooFormatPluginContext.registerDokkaBasePluginConfiguration() {
     with(dokkatooExtension.pluginsConfiguration) {
-      registerFactory(DokkaHtmlPluginParameters::class.java) { named ->
-        objects.newInstance(named)
-      }
+      registerBinding(DokkaHtmlPluginParameters::class, DokkaHtmlPluginParameters::class)
       register<DokkaHtmlPluginParameters>(DOKKA_HTML_PARAMETERS_NAME)
       withType<DokkaHtmlPluginParameters>().configureEach {
         separateInheritedMembers.convention(false)
         mergeImplicitExpectActualDeclarations.convention(false)
       }
+    }
+  }
 
-      registerFactory(DokkaVersioningPluginParameters::class.java) { named ->
-        objects.newInstance(named)
-      }
+  private fun DokkatooFormatPluginContext.registerDokkaVersioningPlugin() {
+    // register and configure Dokka Versioning Plugin
+    with(dokkatooExtension.pluginsConfiguration) {
+      registerBinding(
+        DokkaVersioningPluginParameters::class,
+        DokkaVersioningPluginParameters::class,
+      )
       register<DokkaVersioningPluginParameters>(DOKKA_VERSIONING_PLUGIN_PARAMETERS_NAME)
       withType<DokkaVersioningPluginParameters>().configureEach {
         renderVersionsNavigationOnAllPages.convention(true)

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleExtensionAccessors.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleExtensionAccessors.kt
@@ -5,10 +5,6 @@ import org.gradle.kotlin.dsl.*
 
 // When Dokkatoo is applied to a build script Gradle will auto-generate these accessors
 
-internal val DokkatooExtension.versions: DokkatooExtension.Versions
-  get() = extensions.getByType()
-
-
 internal fun DokkatooExtension.versions(configure: DokkatooExtension.Versions.() -> Unit) {
   versions.apply(configure)
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleTypealiases.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleTypealiases.kt
@@ -4,7 +4,8 @@ import dev.adamko.dokkatoo.dokka.plugins.DokkaPluginParametersBaseSpec
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer
 
 /** Container for all [Dokka Plugin parameters][DokkaPluginParametersBaseSpec]. */
-typealias DokkaPluginParametersContainer = ExtensiblePolymorphicDomainObjectContainer<DokkaPluginParametersBaseSpec>
+typealias DokkaPluginParametersContainer =
+    ExtensiblePolymorphicDomainObjectContainer<DokkaPluginParametersBaseSpec>
 
 
 /**

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooPrepareParametersTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooPrepareParametersTask.kt
@@ -152,8 +152,7 @@ constructor(
 
     val pluginsClasspath = pluginsClasspath.files.toList()
 
-    val pluginsConfiguration =
-      pluginsConfiguration.map(DokkaPluginParametersBaseSpec::build)
+    val pluginsConfiguration = pluginsConfiguration.map(DokkaPluginParametersBaseSpec::build)
     val failOnWarning = failOnWarning.get()
     val delayTemplateSubstitution = delayTemplateSubstitution.get()
     val suppressObviousFunctions = suppressObviousFunctions.get()

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooTask.kt
@@ -3,8 +3,12 @@ package dev.adamko.dokkatoo.tasks
 import dev.adamko.dokkatoo.DokkatooBasePlugin
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+import dev.adamko.dokkatoo.internal.adding
+import dev.adamko.dokkatoo.internal.domainObjectContainer
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Nested
@@ -14,6 +18,9 @@ import org.gradle.api.tasks.Nested
 abstract class DokkatooTask
 @DokkatooInternalApi
 constructor() : DefaultTask() {
+
+  @get:Inject
+  abstract val objects: ObjectFactory
 
   init {
     group = DokkatooBasePlugin.TASK_GROUP
@@ -37,7 +44,8 @@ constructor() : DefaultTask() {
      * task input for up-to-date checks
      */
     @get:Nested
-    abstract val dokkaSourceSets: NamedDomainObjectContainer<DokkaSourceSetSpec>
+    val dokkaSourceSets: NamedDomainObjectContainer<DokkaSourceSetSpec> =
+      extensions.adding("dokkaSourceSets") { objects.domainObjectContainer() }
 
     fun addAllDokkaSourceSets(sourceSets: Provider<Iterable<DokkaSourceSetSpec>>) {
       dokkaSourceSets.addAllLater(sourceSets)


### PR DESCRIPTION
Refactor the extensions so that Gradle automatically generates more type-safe accessors.

* add `*DomainObjectContainers` as extensions, so Gradle generates accessors
* use workaround for https://github.com/gradle/gradle/issues/24972
* add property for `Versions`
* add some utilities for `ObjectFactory`