### PR TITLE
Always call hashCode() on URLs to make sure they serialize correctly

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -210,7 +210,7 @@ constructor(
       externalDocumentationLinks {
         configureEach {
           enabled.convention(true)
-          packageListUrl.convention(url.map { it.appendPath("package-list") })
+          packageListUrl.convention(url.map { it.appendPath("package-list").apply { hashCode() } })
         }
 
         maybeCreate("jdk") {

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpec.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaExternalDocumentationLinkSpec.kt
@@ -65,14 +65,14 @@ constructor(
    *
    * @param[value] will be converted to a [URL]
    */
-  fun url(value: String) = url.set(URL(value))
+  fun url(value: String) = url.set(URL(value).apply { hashCode() })
 
   /**
    * Set the value of [url].
    *
    * @param[value] will be converted to a [URL]
    */
-  fun url(value: Provider<String>) = url.set(value.map(::URL))
+  fun url(value: Provider<String>) = url.set(value.map { URL(it).apply { hashCode() } })
 
   /**
    * Specifies the exact location of a `package-list` instead of relying on Dokka
@@ -92,14 +92,15 @@ constructor(
    *
    * @param[value] will be converted to a [URL]
    */
-  fun packageListUrl(value: String) = packageListUrl.set(URL(value))
+  fun packageListUrl(value: String) = packageListUrl.set(URL(value).apply { hashCode() })
 
   /**
    * Set the value of [packageListUrl].
    *
    * @param[value] will be converted to a [URL]
    */
-  fun packageListUrl(value: Provider<String>) = packageListUrl.set(value.map(::URL))
+  fun packageListUrl(value: Provider<String>) =
+    packageListUrl.set(value.map { URL(it).apply { hashCode() } })
 
   /**
    * If enabled this link will be passed to the Dokka Generator.


### PR DESCRIPTION
So this is a "funny" one... The memoized `URL.hashCode` [is apparently serialized](https://github.com/openjdk/jdk/blob/fc76687c2fac39fcbf706c419bfa170b8efa5747/src/java.base/share/classes/java/net/URL.java#L1777) so in some cases where the URL is brand new and `hashCode()` has never been called, `.hashCode == -1`. 

This means it's possible to end up in cases where `url1.toString() == url2.toString()` but url1 and url2 are serialized differently :/. I consider this PR to be a huge workaround. The fix is certainly to stop using `URL` altogether as task input but my understanding is that it would require bigger (potentially breaking) changes to dokka so merging this would help our builds run faster in the short term.

To reproduce use [gradle-enterprise-build-validation-scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts) (ping me if you need credentials):

```
~/dev/gradle-enterprise-gradle-build-validation/03-validate-local-build-caching-different-locations.sh 
-r https://github.com/apollographql/apollo-kotlin -b dokkatoo -t :apollo-ast:dokkatooGenerate         
```

Example build comparison where cacheable task become executed due to this issu: https://ge.apollographql.com/c/xyflcovun4nhy/t76ikqfb25zku/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure

