### PR TITLE
Fix workaround for nested module directories

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -6,7 +6,6 @@ import dev.adamko.dokkatoo.dokka.parameters.DokkaModuleDescriptionKxs
 import dev.adamko.dokkatoo.dokka.parameters.builders.DokkaParametersBuilder
 import dev.adamko.dokkatoo.internal.DokkaPluginParametersContainer
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
-import dev.adamko.dokkatoo.internal.adding
 import dev.adamko.dokkatoo.workers.DokkaGeneratorWorker
 import java.io.IOException
 import javax.inject.Inject
@@ -158,10 +157,6 @@ constructor(
     }
 
     val dokkaModuleDescriptors = dokkaModuleDescriptors()
-    dokkaModuleDescriptors.forEach {
-      // workaround until https://github.com/Kotlin/dokka/pull/2867 is released
-      this.outputDirectory.dir(it.modulePath).get().asFile.mkdirs()
-    }
 
     return DokkaParametersBuilder.build(
       spec = generator,

--- a/modules/dokkatoo-plugin/src/main/kotlin/workers/DokkaGeneratorWorker.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/workers/DokkaGeneratorWorker.kt
@@ -29,14 +29,24 @@ abstract class DokkaGeneratorWorker : WorkAction<DokkaGeneratorWorker.Parameters
   override fun execute() {
     val dokkaParameters = parameters.dokkaParameters.get()
 
-    // Dokka Generator doesn't clean up old files, so we need to manually clean the output directory
-    dokkaParameters.outputDir.deleteRecursively()
-    dokkaParameters.outputDir.mkdirs()
+    prepareOutputDir(dokkaParameters)
 
     executeDokkaGenerator(
       parameters.logFile.get().asFile,
       dokkaParameters,
     )
+  }
+
+  private fun prepareOutputDir(dokkaParameters: DokkaConfiguration) {
+    // Dokka Generator doesn't clean up old files, so we need to manually clean the output directory
+    dokkaParameters.outputDir.deleteRecursively()
+    dokkaParameters.outputDir.mkdirs()
+
+    // workaround until https://github.com/Kotlin/dokka/pull/2867 is released
+    dokkaParameters.modules.forEach { module ->
+      val moduleDir = dokkaParameters.outputDir.resolve(module.relativePathToOutputDirectory)
+      moduleDir.mkdirs()
+    }
   }
 
   private fun executeDokkaGenerator(


### PR DESCRIPTION
Fix #83 

#60 manually cleaned the directory, which overrode the workaround I employed for https://github.com/Kotlin/dokka/pull/2867

This PR fixes it by manually creating the module directories _after_ the output directory is cleaned.