### PR TITLE
improve URL logging link

### DIFF
--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
@@ -28,7 +28,7 @@ class CustomFormatExampleTest : FunSpec({
   context("compare dokka and dokkatoo HTML generators") {
     test("expect dokka can generate HTML") {
       val dokkaBuild = dokkaProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           "dokkaHtml",
           "--stacktrace",
@@ -43,7 +43,7 @@ class CustomFormatExampleTest : FunSpec({
 
     test("expect dokkatoo can generate HTML") {
       val dokkatooBuild = dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
@@ -84,7 +84,7 @@ class CustomFormatExampleTest : FunSpec({
   context("Gradle caching") {
     test("expect Dokkatoo is compatible with Gradle Build Cache") {
       val dokkatooBuild = dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
@@ -102,7 +102,7 @@ class CustomFormatExampleTest : FunSpec({
       dokkaWorkerLog.readText() shouldContain "Generation completed successfully"
 
       dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--build-cache",
@@ -128,7 +128,7 @@ class CustomFormatExampleTest : FunSpec({
 
       val configCacheRunner =
         dokkatooProject.runner
-          .withArguments(
+          .addArguments(
             "clean",
             ":dokkatooGeneratePublicationHtml",
             "--stacktrace",

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
@@ -30,7 +30,7 @@ class GradleExampleTest : FunSpec({
   context("compare dokka and dokkatoo HTML generators") {
     test("expect dokka can generate HTML") {
       val dokkaBuild = dokkaProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           "dokkaHtml",
           "--stacktrace",
@@ -45,7 +45,7 @@ class GradleExampleTest : FunSpec({
 
     test("expect dokkatoo can generate HTML") {
       val dokkatooBuild = dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
@@ -86,7 +86,7 @@ class GradleExampleTest : FunSpec({
   context("Gradle caching") {
     test("expect Dokkatoo is compatible with Gradle Build Cache") {
       val dokkatooBuild = dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
@@ -104,7 +104,7 @@ class GradleExampleTest : FunSpec({
       dokkaWorkerLog.readText() shouldContain "Generation completed successfully"
 
       dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--info",
@@ -130,7 +130,7 @@ class GradleExampleTest : FunSpec({
 
       val configCacheRunner =
         dokkatooProject.runner
-          .withArguments(
+          .addArguments(
             "clean",
             ":dokkatooGeneratePublicationHtml",
             "--stacktrace",

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/KotlinMultiplatformExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/KotlinMultiplatformExampleTest.kt
@@ -27,7 +27,7 @@ class KotlinMultiplatformExampleTest : FunSpec({
   context("compare dokka and dokkatoo HTML generators") {
     test("expect dokka can generate HTML") {
       val dokkaBuild = dokkaProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           "dokkaHtml",
           "--stacktrace",
@@ -42,7 +42,7 @@ class KotlinMultiplatformExampleTest : FunSpec({
 
     context("when Dokkatoo generates HTML") {
       val build = dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
@@ -92,7 +92,7 @@ class KotlinMultiplatformExampleTest : FunSpec({
 
     context("expect Dokkatoo is compatible with Gradle Build Cache") {
       val build = dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
@@ -119,7 +119,7 @@ class KotlinMultiplatformExampleTest : FunSpec({
 
       test("expect tasks are UP-TO-DATE") {
         dokkatooProject.runner
-          .withArguments(
+          .addArguments(
             ":dokkatooGeneratePublicationHtml",
             "--stacktrace",
             "--info",
@@ -153,7 +153,7 @@ class KotlinMultiplatformExampleTest : FunSpec({
 
       val configCacheRunner =
         dokkatooProject.runner
-          .withArguments(
+          .addArguments(
             "clean",
             ":dokkatooGeneratePublicationHtml",
             "--stacktrace",

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
@@ -28,7 +28,7 @@ class MultimoduleExampleTest : FunSpec({
   context("compare dokka and dokkatoo HTML generators") {
     test("expect dokka can generate HTML") {
       val dokkaBuild = dokkaProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           "dokkaHtmlMultiModule",
           "--stacktrace",
@@ -43,7 +43,7 @@ class MultimoduleExampleTest : FunSpec({
 
     context("when Dokkatoo generates HTML") {
       val build = dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--stacktrace",
@@ -93,7 +93,7 @@ class MultimoduleExampleTest : FunSpec({
 
     context("expect Dokkatoo is compatible with Gradle Build Cache") {
       val build = dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "clean",
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--stacktrace",
@@ -120,7 +120,7 @@ class MultimoduleExampleTest : FunSpec({
 
       test("expect tasks are UP-TO-DATE") {
         dokkatooProject.runner
-          .withArguments(
+          .addArguments(
             ":parentProject:dokkatooGeneratePublicationHtml",
             "--stacktrace",
             "--info",
@@ -147,7 +147,7 @@ class MultimoduleExampleTest : FunSpec({
 
       val configCacheRunner =
         dokkatooProject.runner
-          .withArguments(
+          .addArguments(
             "clean",
             ":parentProject:dokkatooGeneratePublicationHtml",
             "--stacktrace",

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
@@ -27,7 +27,7 @@ class AndroidProjectIntegrationTest : FunSpec({
 
   context("when generating HTML") {
     val dokkaBuild = dokkaProject.runner
-      .withArguments(
+      .addArguments(
         "clean",
         "dokkaHtml",
         "--stacktrace",
@@ -36,7 +36,7 @@ class AndroidProjectIntegrationTest : FunSpec({
       .build()
 
     val dokkatooBuild = dokkatooProject.runner
-      .withArguments(
+      .addArguments(
         "clean",
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",
@@ -98,7 +98,7 @@ class AndroidProjectIntegrationTest : FunSpec({
 
     test("Dokkatoo tasks should be cacheable") {
       dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--build-cache",
@@ -117,7 +117,7 @@ class AndroidProjectIntegrationTest : FunSpec({
 
       val configCacheRunner =
         dokkatooProject.runner
-          .withArguments(
+          .addArguments(
             "clean",
             "dokkatooGeneratePublicationHtml",
             "--stacktrace",

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -29,7 +29,7 @@ class BasicProjectIntegrationTest : FunSpec({
 
   context("when generating HTML") {
     val dokkaBuild = dokkaProject.runner
-      .withArguments(
+      .addArguments(
         "clean",
         "dokkaHtml",
         "--stacktrace",
@@ -38,7 +38,7 @@ class BasicProjectIntegrationTest : FunSpec({
       .build()
 
     val dokkatooBuild = dokkatooProject.runner
-      .withArguments(
+      .addArguments(
         "clean",
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",
@@ -100,7 +100,7 @@ class BasicProjectIntegrationTest : FunSpec({
 
     test("Dokkatoo tasks should be cacheable") {
       dokkatooProject.runner
-        .withArguments(
+        .addArguments(
           "dokkatooGeneratePublicationHtml",
           "--stacktrace",
           "--build-cache",
@@ -119,7 +119,7 @@ class BasicProjectIntegrationTest : FunSpec({
 
       val configCacheRunner =
         dokkatooProject.runner
-          .withArguments(
+          .addArguments(
             "clean",
             "dokkatooGeneratePublicationHtml",
             "--stacktrace",

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -412,8 +412,13 @@ public abstract class dev/adamko/dokkatoo/tasks/DokkatooTask$WithSourceSets : de
 }
 
 public abstract class dev/adamko/dokkatoo/tasks/LogHtmlPublicationLinkTask : dev/adamko/dokkatoo/tasks/DokkatooTask {
+	public static final field Companion Ldev/adamko/dokkatoo/tasks/LogHtmlPublicationLinkTask$Companion;
+	public static final field ENABLE_TASK_PROPERTY_NAME Ljava/lang/String;
 	public final fun exec ()V
 	public abstract fun getIndexHtmlPath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getServerUri ()Lorg/gradle/api/provider/Property;
+}
+
+public final class dev/adamko/dokkatoo/tasks/LogHtmlPublicationLinkTask$Companion {
 }
 

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -411,3 +411,9 @@ public abstract class dev/adamko/dokkatoo/tasks/DokkatooTask$WithSourceSets : de
 	public abstract fun getDokkaSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
 }
 
+public abstract class dev/adamko/dokkatoo/tasks/LogHtmlPublicationLinkTask : dev/adamko/dokkatoo/tasks/DokkatooTask {
+	public final fun exec ()V
+	public abstract fun getIndexHtmlPath ()Lorg/gradle/api/provider/Property;
+	public abstract fun getServerUri ()Lorg/gradle/api/provider/Property;
+}
+

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -292,12 +292,6 @@ constructor(
       @OptIn(ExperimentalSerializationApi::class)
       prettyPrintIndent = "  "
     }
-
-    private fun URI.appendPath(addition: String): URI {
-      val currentPath = path.removeSuffix("/")
-      val newPath = "$currentPath/$addition"
-      return resolve(newPath).normalize()
-    }
   }
 
   @DokkatooInternalApi

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooHtmlPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooHtmlPlugin.kt
@@ -5,6 +5,9 @@ import dev.adamko.dokkatoo.dokka.plugins.DokkaHtmlPluginParameters.Companion.DOK
 import dev.adamko.dokkatoo.dokka.plugins.DokkaVersioningPluginParameters
 import dev.adamko.dokkatoo.dokka.plugins.DokkaVersioningPluginParameters.Companion.DOKKA_VERSIONING_PLUGIN_PARAMETERS_NAME
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
+import dev.adamko.dokkatoo.internal.uppercaseFirstChar
+import dev.adamko.dokkatoo.tasks.LogHtmlPublicationLinkTask
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
 
 abstract class DokkatooHtmlPlugin
@@ -15,12 +18,10 @@ constructor() : DokkatooFormatPlugin(formatName = "html") {
     registerDokkaBasePluginConfiguration()
     registerDokkaVersioningPlugin()
 
+    val logHtmlUrlTask = registerLogHtmlUrlTask()
+
     dokkatooTasks.generatePublication.configure {
-      doLast {
-        val indexHtml =
-          outputDirectory.asFile.orNull?.resolve("index.html")?.invariantSeparatorsPath
-        logger.lifecycle("Generated Dokka HTML publication: file://$indexHtml")
-      }
+      finalizedBy(logHtmlUrlTask)
     }
   }
 
@@ -46,6 +47,26 @@ constructor() : DokkatooFormatPlugin(formatName = "html") {
       withType<DokkaVersioningPluginParameters>().configureEach {
         renderVersionsNavigationOnAllPages.convention(true)
       }
+    }
+  }
+
+  private fun DokkatooFormatPluginContext.registerLogHtmlUrlTask():
+      TaskProvider<LogHtmlPublicationLinkTask> {
+
+    val indexHtmlFile = dokkatooTasks.generatePublication
+      .flatMap { it.outputDirectory.file("index.html") }
+
+    val indexHtmlPath = indexHtmlFile.map { indexHtml ->
+      indexHtml.asFile
+        .relativeTo(project.rootDir.parentFile)
+        .invariantSeparatorsPath
+    }
+
+    return project.tasks.register<LogHtmlPublicationLinkTask>(
+      "logLink" + dokkatooTasks.generatePublication.name.uppercaseFirstChar()
+    ) {
+      serverUri.convention("http://localhost:63342")
+      this.indexHtmlPath.convention(indexHtmlPath)
     }
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/uriUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/uriUtils.kt
@@ -1,0 +1,9 @@
+package dev.adamko.dokkatoo.internal
+
+import java.net.URI
+
+internal fun URI.appendPath(addition: String): URI {
+  val currentPath = path.removeSuffix("/")
+  val newPath = "$currentPath/$addition"
+  return resolve(newPath).normalize()
+}

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -22,9 +22,14 @@ class GradleProjectTest(
     baseDir: Path = funcTestTempDir,
   ) : this(projectDir = baseDir.resolve(testProjectName))
 
-  val runner: GradleRunner = GradleRunner.create()
-    .withProjectDir(projectDir.toFile())
-    .withJvmArguments("-XX:MaxMetaspaceSize=512m")
+  val runner: GradleRunner
+    get() = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withJvmArguments("-XX:MaxMetaspaceSize=512m")
+      .addArguments(
+        // disable the logging task so the tests work consistently on local machines and CI/CD
+        "-P" + "dev.adamko.dokkatoo.tasks.logHtmlPublicationLinkEnabled=false"
+      )
 
   val testMavenRepoRelativePath: String =
     projectDir.relativize(testMavenRepoDir).toFile().invariantSeparatorsPath
@@ -93,8 +98,8 @@ fun gradleKtsProjectTest(
       |
       |pluginManagement {
       |  repositories {
-      |    gradlePluginPortal()
       |    mavenCentral()
+      |    gradlePluginPortal()
       |    maven(file("$testMavenRepoRelativePath")) {
       |      mavenContent {
       |        includeGroup("dev.adamko.dokkatoo")
@@ -140,8 +145,8 @@ fun gradleGroovyProjectTest(
       |
       |pluginManagement {
       |    repositories {
-      |        gradlePluginPortal()
       |        mavenCentral()
+      |        gradlePluginPortal()
       |        maven { url = file("$testMavenRepoRelativePath") }
       |    }
       |}
@@ -254,7 +259,9 @@ var ProjectDirectoryScope.buildGradle: String by TestProjectFileDelegate("build.
 
 /** Set the content of `gradle.properties` */
 @delegate:Language("properties")
-var ProjectDirectoryScope.gradleProperties: String by TestProjectFileDelegate("gradle.properties")
+var ProjectDirectoryScope.gradleProperties: String by TestProjectFileDelegate(
+  /* language=text */ "gradle.properties"
+)
 
 
 fun ProjectDirectoryScope.createKotlinFile(filePath: String, @Language("kotlin") contents: String) =

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
@@ -1,6 +1,7 @@
 package dev.adamko.dokkatoo.utils
 
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.DefaultGradleRunner
 
@@ -27,3 +28,20 @@ inline fun GradleRunner.buildAndFail(
 fun GradleRunner.withJvmArguments(
   vararg jvmArguments: String
 ): GradleRunner = (this as DefaultGradleRunner).withJvmArguments(*jvmArguments)
+
+
+/**
+ * Helper function to _append_ [arguments] to any existing
+ * [GradleRunner arguments][GradleRunner.getArguments].
+ */
+fun GradleRunner.addArguments(
+  vararg arguments: String
+): GradleRunner =
+  withArguments(this@addArguments.arguments + arguments)
+
+
+/**
+ * Get the name of the task, without the leading [BuildTask.getPath].
+ */
+val BuildTask.name: String
+  get() = path.substringAfterLast(':')

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
@@ -20,7 +20,7 @@ class DokkatooPluginFunctionalTest : FunSpec({
 
   test("expect Dokka Plugin creates Dokka tasks") {
     val build = testProject.runner
-      .withArguments("tasks", "--group=dokkatoo", "-q")
+      .addArguments("tasks", "--group=dokkatoo", "-q")
       .build()
 
     withClue(build.output) {
@@ -57,7 +57,7 @@ class DokkatooPluginFunctionalTest : FunSpec({
 
   test("expect Dokka Plugin creates Dokka outgoing variants") {
     val build = testProject.runner
-      .withArguments("outgoingVariants", "-q")
+      .addArguments("outgoingVariants", "-q")
       .build()
 
     val variants = build.output.invariantNewlines().replace('\\', '/')
@@ -125,7 +125,7 @@ class DokkatooPluginFunctionalTest : FunSpec({
     val expectedFormats = listOf("Gfm", "Html", "Javadoc", "Jekyll")
 
     val build = testProject.runner
-      .withArguments("resolvableConfigurations", "-q")
+      .addArguments("resolvableConfigurations", "-q")
       .build()
 
     build.output.invariantNewlines().asClue { allConfigurations ->

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/GradlePluginProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/GradlePluginProjectIntegrationTest.kt
@@ -15,7 +15,7 @@ class GradlePluginProjectIntegrationTest : FunSpec({
     val project = initGradlePluginProject()
 
     val dokkatooBuild = project.runner
-      .withArguments(
+      .addArguments(
         "clean",
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinMultiplatformFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinMultiplatformFunctionalTest.kt
@@ -19,7 +19,7 @@ class KotlinMultiplatformFunctionalTest : FunSpec({
     val project = initKotlinMultiplatformProject()
 
     project.runner
-      .withArguments(
+      .addArguments(
         "clean",
         ":dokkatooGeneratePublicationHtml",
         "--stacktrace",


### PR DESCRIPTION
improve URL logging link, so it logs a clickable URL that uses IntelliJ's built-in server by default