### PR TITLE
increase the ServerActiveCheck timeout because 10ms is toooo faaaaaast

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/LogHtmlPublicationLinkTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/LogHtmlPublicationLinkTask.kt
@@ -123,7 +123,7 @@ constructor(
         val request = HttpRequest
           .newBuilder()
           .uri(uri)
-          .timeout(Duration.ofMillis(10))
+          .timeout(Duration.ofSeconds(1))
           .GET()
           .build()
         val response = client.send(request, HttpResponse.BodyHandlers.ofString())


### PR DESCRIPTION
1 second seems to be more than enough. There doesn't seem to be a downside to having a long timeout - the check fails almost instantly if IntelliJ isn't running (which isn't what I originally thought).

I used this task to experiment: 

```kotlin
//build.gradle.kts


import java.net.URI
import java.net.http.HttpClient
import java.net.http.HttpRequest
import java.net.http.HttpResponse
import java.time.Duration
import kotlin.time.ExperimentalTime
import kotlin.time.TimeSource
import kotlin.time.measureTimedValue

@OptIn(ExperimentalTime::class)
val urlTimeoutCheck by tasks.registering {
  doLast {

    repeat(100) {
      Thread.sleep(500)
      val timeMark = TimeSource.Monotonic.markNow()
      runCatching {
        val uri = URI.create("http://localhost:63342")
        val client = HttpClient.newHttpClient()
        val request = HttpRequest
          .newBuilder()
          .uri(uri)
//          .timeout(Duration.ofMillis(100))
          .GET()
          .build()
        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
        println("HTTP${response.statusCode()} in ${timeMark.elapsedNow()}")
      }.onFailure { println("failed in ${timeMark.elapsedNow()}") }
    }
  }
}

```