### PR TITLE
Integration Test setup: fix relative path error for Android SDK

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/android-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/android-setup.gradle.kts
@@ -1,12 +1,6 @@
 package buildsrc.conventions
 
-import buildsrc.tasks.SetupDokkaProjects
-import java.io.File
-import java.time.Duration
-import org.gradle.api.provider.Provider
-import org.gradle.kotlin.dsl.*
-import buildsrc.utils.skipTestFixturesPublications
-import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer
 import org.jetbrains.kotlin.util.suffixIfNot
 
 
@@ -27,18 +21,15 @@ val androidSdkDir: Provider<File> = providers
   .orElse(layout.projectDirectory.file("projects/ANDROID_SDK").asFile)
 
 
-
 val createAndroidLocalPropertiesFile by tasks.registering {
 
   val localPropertiesFile = temporaryDir.resolve("local.properties")
   outputs.file(localPropertiesFile).withPropertyName("localPropertiesFile")
 
   val androidSdkDir = androidSdkDir
-  // add the relative path as a property for Gradle up-to-date checks (the directory contents don't matter)
-  inputs.property(
-    "androidSdkDirPath",
-    androidSdkDir.map { it.relativeTo(projectDir).invariantSeparatorsPath }
-  )
+  inputs.file(androidSdkDir)
+    .withPropertyName("androidSdkDir")
+    .withNormalizer(IgnoredPathInputNormalizer::class)
 
   doLast {
     val androidSdkPath = androidSdkDir.get().invariantSeparatorsPath

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/android-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/android-setup.gradle.kts
@@ -27,7 +27,7 @@ val createAndroidLocalPropertiesFile by tasks.registering {
   outputs.file(localPropertiesFile).withPropertyName("localPropertiesFile")
 
   val androidSdkDir = androidSdkDir
-  inputs.file(androidSdkDir)
+  inputs.dir(androidSdkDir)
     .withPropertyName("androidSdkDir")
     .withNormalizer(IgnoredPathInputNormalizer::class)
 
@@ -61,7 +61,7 @@ val updateAndroidLocalProperties by tasks.registering {
   outputs.files(localPropertiesFiles).withPropertyName("localPropertiesFiles")
 
   val androidSdkDir = androidSdkDir
-  inputs.file(androidSdkDir)
+  inputs.dir(androidSdkDir)
     .withPropertyName("androidSdkDir")
     .withNormalizer(IgnoredPathInputNormalizer::class)
 

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/android-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/android-setup.gradle.kts
@@ -53,26 +53,24 @@ val createAndroidLocalPropertiesFile by tasks.registering {
 val updateAndroidLocalProperties by tasks.registering {
 
   // find all local.properties files
-  val localPropertiesFiles = layout.projectDirectory.dir("projects").asFileTree
-    .matching {
-      include("**/local.properties")
-    }.files
+  val localPropertiesFiles = layout.projectDirectory.dir("projects")
+    .asFileTree
+    .matching { include("**/local.properties") }
+    .files
 
   outputs.files(localPropertiesFiles).withPropertyName("localPropertiesFiles")
 
   val androidSdkDir = androidSdkDir
-
-  // add the relative path as a property for Gradle up-to-date checks (the directory contents don't matter)
-  inputs.property(
-    "androidSdkDirPath",
-    androidSdkDir.map { it.relativeTo(projectDir).invariantSeparatorsPath }
-  )
+  inputs.file(androidSdkDir)
+    .withPropertyName("androidSdkDir")
+    .withNormalizer(IgnoredPathInputNormalizer::class)
 
   doLast {
     val androidSdkDirPath = androidSdkDir.get().invariantSeparatorsPath
 
-    localPropertiesFiles.forEach { file ->
-      if (file.exists()) {
+    localPropertiesFiles
+      .filter { it.exists() }
+      .forEach { file ->
         file.writeText(
           file.useLines { lines ->
             lines.joinToString("\n") { line ->
@@ -84,6 +82,5 @@ val updateAndroidLocalProperties by tasks.registering {
           }
         )
       }
-    }
   }
 }


### PR DESCRIPTION

Fix this error which happens on GitHub Windows CI

```
IllegalArgumentException: this and base files have different roots: C:\Android\android-sdk and D:\a\dokkatoo\dokkatoo\modules\dokkatoo-plugin-integration-tests.
```