### PR TITLE
add readme.txt to Javadoc JAR

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-gradle-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-gradle-plugin.gradle.kts
@@ -10,3 +10,28 @@ plugins {
 tasks.validatePlugins {
   enableStricterValidation.set(true)
 }
+
+val createJavadocJarReadme by tasks.registering(Sync::class) {
+  description = "generate a readme.txt for the Javadoc JAR"
+  from(
+    resources.text.fromString(
+      """
+      This Javadoc JAR is intentionally empty.
+      
+      For documentation, see the sources JAR or https://github.com/adamko-dev/dokkatoo/
+      
+    """.trimIndent()
+    )
+  ) {
+    rename { "readme.txt" }
+  }
+  into(temporaryDir)
+}
+
+
+// The Gradle Publish Plugin enables the Javadoc JAR in afterEvaluate, so find it lazily
+tasks.withType<Jar>()
+  .matching { it.name == "javadocJar" }
+  .configureEach {
+    from(createJavadocJarReadme)
+  }


### PR DESCRIPTION
Add readme so it's clear the Javadoc JAR is intentionally empty.

fix #98 