### PR TITLE
minor Windows integration tests improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,8 @@ jobs:
             task: "check --continue"
           - os: ubuntu-latest
             task: "check --continue"
-          # don't run integration tests on Windows because Gradle OOMs
           - os: windows-latest
+            # don't run integration tests on Windows because Gradle OOMs https://github.com/adamko-dev/dokkatoo/issues/10
             task: "check --continue -x :modules:dokkatoo-plugin-integration-tests:check"
       fail-fast: false
     uses: ./.github/workflows/gradle_task.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,14 @@ jobs:
   gradle-check:
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
-        task:
-          - "check --continue"
+        include:
+          - os: macos-latest
+            task: "check --continue"
+          - os: ubuntu-latest
+            task: "check --continue"
+          # don't run integration tests on Windows because Gradle OOMs
+          - os: windows-latest
+            task: "check --continue -x :modules:dokkatoo-plugin-integration-tests:check"
       fail-fast: false
     uses: ./.github/workflows/gradle_task.yml
     with:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
@@ -1,7 +1,6 @@
 package dev.adamko.dokkatoo.tests.integration
 
 import dev.adamko.dokkatoo.utils.*
-import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.file.shouldBeAFile
 import io.kotest.matchers.file.shouldHaveSameStructureAndContentAs
@@ -18,7 +17,6 @@ import kotlin.io.path.deleteIfExists
  *
  * Runs Dokka & Dokkatoo, and compares the resulting HTML site.
  */
-@EnabledIf(NotWindowsCondition::class) // https://github.com/adamko-dev/dokkatoo/issues/10
 class AndroidProjectIntegrationTest : FunSpec({
 
   val tempDir = GradleProjectTest.projectTestTempDir.resolve("it/it-android-0").toFile()

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -1,9 +1,7 @@
 package dev.adamko.dokkatoo.tests.integration
 
-import dev.adamko.dokkatoo.internal.DokkatooConstants.DOKKA_VERSION
 import dev.adamko.dokkatoo.utils.*
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
-import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.file.shouldBeAFile
 import io.kotest.matchers.file.shouldHaveSameStructureAndContentAs
@@ -19,7 +17,6 @@ import java.io.File
  *
  * Runs Dokka & Dokkatoo, and compares the resulting HTML site.
  */
-@EnabledIf(NotWindowsCondition::class) // https://github.com/adamko-dev/dokkatoo/issues/10
 class BasicProjectIntegrationTest : FunSpec({
 
   val tempDir = projectTestTempDir.resolve("it/it-basic").toFile()

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -75,9 +75,6 @@ constructor(
       cacheDirectory.convention(dokkatooExtension.dokkatooCacheDirectory)
       workerDebugEnabled.convention(false)
       workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
-      // increase memory - DokkaGenerator is hungry https://github.com/Kotlin/dokka/issues/1405
-//      workerMinHeapSize.convention("512m")
-//      workerMaxHeapSize.convention("1g")
       workerJvmArgs.set(
         listOf(
           //"-XX:MaxMetaspaceSize=512m",

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -76,8 +76,8 @@ constructor(
       workerDebugEnabled.convention(false)
       workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
       // increase memory - DokkaGenerator is hungry https://github.com/Kotlin/dokka/issues/1405
-      workerMinHeapSize.convention("512m")
-      workerMaxHeapSize.convention("1g")
+//      workerMinHeapSize.convention("512m")
+//      workerMaxHeapSize.convention("1g")
       workerJvmArgs.set(
         listOf(
           //"-XX:MaxMetaspaceSize=512m",

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -78,9 +78,11 @@ constructor(
   abstract val workerDebugEnabled: Property<Boolean>
   /** @see JavaForkOptions.getMinHeapSize */
   @get:Input
+  @get:Optional
   abstract val workerMinHeapSize: Property<String>
   /** @see JavaForkOptions.getMaxHeapSize */
   @get:Input
+  @get:Optional
   abstract val workerMaxHeapSize: Property<String>
   /** @see JavaForkOptions.jvmArgs */
   @get:Input

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -113,8 +113,8 @@ constructor(
       classpath.from(runtimeClasspath)
       forkOptions {
         defaultCharacterEncoding = "UTF-8"
-        minHeapSize = workerMinHeapSize.get()
-        maxHeapSize = workerMaxHeapSize.get()
+        minHeapSize = workerMinHeapSize.orNull
+        maxHeapSize = workerMaxHeapSize.orNull
         enableAssertions = true
         debug = workerDebugEnabled.get()
         jvmArgs = workerJvmArgs.get()

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/stringUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/stringUtils.kt
@@ -13,6 +13,7 @@ private inline fun String.mapFirstChar(
   transform: (Char) -> Char
 ): String = if (isNotEmpty()) transform(this[0]) + substring(1) else this
 
+
 /** Split a string into lines, sort the lines, and re-join them (using [separator]). */
 fun String.sortLines(separator: String = "\n") =
   lines()

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/stringUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/stringUtils.kt
@@ -1,5 +1,6 @@
 package dev.adamko.dokkatoo.utils
 
+
 fun String.splitToPair(delimiter: String): Pair<String, String> =
   substringBefore(delimiter) to substringAfter(delimiter)
 
@@ -11,3 +12,9 @@ fun String.uppercaseFirstChar(): String = mapFirstChar(Character::toTitleCase)
 private inline fun String.mapFirstChar(
   transform: (Char) -> Char
 ): String = if (isNotEmpty()) transform(this[0]) + substring(1) else this
+
+/** Split a string into lines, sort the lines, and re-join them (using [separator]). */
+fun String.sortLines(separator: String = "\n") =
+  lines()
+    .sorted()
+    .joinToString(separator)

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinMultiplatformFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinMultiplatformFunctionalTest.kt
@@ -58,6 +58,7 @@ class KotlinMultiplatformFunctionalTest : FunSpec({
       test("with element-list") {
         project.projectDir.resolve("build/dokka/html/test/package-list").shouldBeAFile()
         project.projectDir.resolve("build/dokka/html/test/package-list").toFile().readText()
+          .sortLines()
           .shouldContain( /* language=text */ """
               |${'$'}dokka.format:html-v1
               |${'$'}dokka.linkExtension:html
@@ -67,7 +68,6 @@ class KotlinMultiplatformFunctionalTest : FunSpec({
               |${'$'}dokka.location:com.project/Hello/Hello/#/PointingToDeclaration/test/com.project/-hello/-hello.html
               |${'$'}dokka.location:com.project/Hello/sayHello/#kotlinx.serialization.json.JsonObject/PointingToDeclaration/test/com.project/-hello/say-hello.html
               |com.project
-              |
             """.trimMargin()
           )
       }


### PR DESCRIPTION
* Update to Gradle 8.2.1
* re-enable integration tests on Windows
* fix KotlinMultiplatformFunctionalTest by sorting the text lines
* Remove default Dokka Generator Worker heap sizes - the Gradle default sizes seem to work fine

helps with #10, but the Windows integration tests still fail due to OOM errors.