### PR TITLE
Update Dokka to 1.9.0

### DIFF
--- a/examples/custom-format-example/dokka/build.gradle.kts
+++ b/examples/custom-format-example/dokka/build.gradle.kts
@@ -3,13 +3,13 @@ import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 
 plugins {
-    kotlin("jvm") version "1.8.20"
-    id("org.jetbrains.dokka") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
+    id("org.jetbrains.dokka") version "1.9.0"
 }
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.dokka:dokka-base:1.8.20")
+        classpath("org.jetbrains.dokka:dokka-base:1.9.0")
     }
 }
 

--- a/examples/custom-format-example/dokka/logo-styles.css
+++ b/examples/custom-format-example/dokka/logo-styles.css
@@ -1,20 +1,20 @@
 /*
  * All Margins and sizes are custom for the ktor-logo.png file.
- * You may need to modify it and find what works best for your case.
+ * You may need to override it and find what works best for your case.
  */
-.library-name a {
-    position: relative;
-    margin-left: 55px;
+:root {
+    --dokka-logo-image-url: url('../images/ktor-logo.png');
+    --dokka-logo-height: 125px;
+    --dokka-logo-width: 50px;
 }
 
-.library-name a::before {
-    content: '';
-    background-image: url('../images/ktor-logo.png');
-    background-repeat: no-repeat;
-    background-size: 125px 50px;
-    position: absolute;
+/* link custom rules styles */
+.library-name--link {
+    /* ... */
+}
+
+/* logo custom rules styles */
+.library-name--link::before {
+    background-position: left;
     width: 52px;
-    height: 50px;
-    top: -18px;
-    left: -62px;
 }

--- a/examples/custom-format-example/dokkatoo/build.gradle.kts
+++ b/examples/custom-format-example/dokkatoo/build.gradle.kts
@@ -1,14 +1,18 @@
 plugins {
-  kotlin("jvm") version "1.8.22"
+  kotlin("jvm") version "1.9.0"
   id("dev.adamko.dokkatoo") version "2.0.0-SNAPSHOT"
 }
 
 dokkatoo {
   moduleName.set("customFormat-example")
   pluginsConfiguration.html {
-    // Custom format adds a custom logo
+    // Dokka's stylesheets and assets with conflicting names will be overridden.
+    // In this particular case, logo-styles.css will be overridden
+    // and ktor-logo.png will be added as an additional image asset
     customStyleSheets.from("logo-styles.css")
     customAssets.from("ktor-logo.png")
+
+    // Text used in the footer
     footerMessage.set("(c) Custom Format Dokka example")
   }
 }

--- a/examples/custom-format-example/dokkatoo/logo-styles.css
+++ b/examples/custom-format-example/dokkatoo/logo-styles.css
@@ -1,20 +1,20 @@
 /*
  * All Margins and sizes are custom for the ktor-logo.png file.
- * You may need to modify it and find what works best for your case.
+ * You may need to override it and find what works best for your case.
  */
-.library-name a {
-    position: relative;
-    margin-left: 55px;
+:root {
+    --dokka-logo-image-url: url('../images/ktor-logo.png');
+    --dokka-logo-height: 125px;
+    --dokka-logo-width: 50px;
 }
 
-.library-name a::before {
-    content: '';
-    background-image: url('../images/ktor-logo.png');
-    background-repeat: no-repeat;
-    background-size: 125px 50px;
-    position: absolute;
+/* link custom rules styles */
+.library-name--link {
+    /* ... */
+}
+
+/* logo custom rules styles */
+.library-name--link::before {
+    background-position: left;
     width: 52px;
-    height: 50px;
-    top: -18px;
-    left: -62px;
 }

--- a/examples/gradle-example/dokka/build.gradle.kts
+++ b/examples/gradle-example/dokka/build.gradle.kts
@@ -2,8 +2,8 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
 
 plugins {
-    kotlin("jvm") version "1.8.20"
-    id("org.jetbrains.dokka") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
+    id("org.jetbrains.dokka") version "1.9.0"
 }
 
 repositories {

--- a/examples/gradle-example/dokkatoo/build.gradle.kts
+++ b/examples/gradle-example/dokkatoo/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm") version "1.8.22"
+  kotlin("jvm") version "1.9.0"
   id("dev.adamko.dokkatoo") version "2.0.0-SNAPSHOT"
 }
 

--- a/examples/kotlin-as-java-example/dokka/build.gradle.kts
+++ b/examples/kotlin-as-java-example/dokka/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.8.20"
-    id("org.jetbrains.dokka") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
+    id("org.jetbrains.dokka") version "1.9.0"
 }
 
 repositories {
@@ -11,11 +11,11 @@ dependencies {
     testImplementation(kotlin("test-junit"))
 
     // Will apply the plugin to all Dokka tasks
-    dokkaPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.8.20")
+    dokkaPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.9.0")
 
     // Will apply the plugin only to the `:dokkaHtml` task
-    //dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.8.20")
+    //dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.9.0")
 
     // Will apply the plugin only to the `:dokkaGfm` task
-    //dokkaGfmPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.8.20")
+    //dokkaGfmPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.9.0")
 }

--- a/examples/library-publishing-example/dokka/build.gradle.kts
+++ b/examples/library-publishing-example/dokka/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.8.20"
-    id("org.jetbrains.dokka") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
+    id("org.jetbrains.dokka") version "1.9.0"
     `java-library`
     `maven-publish`
 }

--- a/examples/multimodule-example/dokkatoo/buildSrc/build.gradle.kts
+++ b/examples/multimodule-example/dokkatoo/buildSrc/build.gradle.kts
@@ -1,10 +1,8 @@
-import org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
-
 plugins {
   `kotlin-dsl`
 }
 
 dependencies {
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
   implementation("dev.adamko.dokkatoo:dokkatoo-plugin:2.0.0-SNAPSHOT")
 }

--- a/examples/multiplatform-example/dokka/build.gradle.kts
+++ b/examples/multiplatform-example/dokka/build.gradle.kts
@@ -4,8 +4,8 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.dokka.Platform
 
 plugins {
-    kotlin("multiplatform") version "1.8.20"
-    id("org.jetbrains.dokka") version "1.8.20"
+    kotlin("multiplatform") version "1.9.0"
+    id("org.jetbrains.dokka") version "1.9.0"
 }
 
 repositories {
@@ -19,7 +19,7 @@ kotlin {
     jvm() // Creates a JVM target with the default name "jvm"
     linuxX64("linux")
     macosX64("macos")
-    js(BOTH)
+    js()
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/examples/multiplatform-example/dokka/src/linuxMain/kotlin/org/kotlintestmpp/cinterop.kt
+++ b/examples/multiplatform-example/dokka/src/linuxMain/kotlin/org/kotlintestmpp/cinterop.kt
@@ -4,10 +4,12 @@ package org.kotlintestmpp
 
 import kotlinx.cinterop.CPointed
 import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
 
 /**
  * Low-level Linux function
  */
+@OptIn(ExperimentalForeignApi::class)
 fun <T : CPointed> printPointerRawValue(pointer: CPointer<T>) {
     println(pointer.rawValue)
 }

--- a/examples/multiplatform-example/dokkatoo/src/linuxMain/kotlin/org/kotlintestmpp/CInterop.kt
+++ b/examples/multiplatform-example/dokkatoo/src/linuxMain/kotlin/org/kotlintestmpp/CInterop.kt
@@ -4,10 +4,12 @@ package org.kotlintestmpp
 
 import kotlinx.cinterop.CPointed
 import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
 
 /**
  * Low-level Linux function
  */
+@OptIn(ExperimentalForeignApi::class)
 fun <T : CPointed> printPointerRawValue(pointer: CPointer<T>) {
     println(pointer.rawValue)
 }

--- a/examples/versioning-multimodule-example/dokka/build.gradle.kts
+++ b/examples/versioning-multimodule-example/dokka/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.8.20"
-    id("org.jetbrains.dokka") version "1.8.20" apply false
+    kotlin("jvm") version "1.9.0"
+    id("org.jetbrains.dokka") version "1.9.0" apply false
 }
 
 // The versioning plugin must be applied in all submodules
@@ -14,6 +14,6 @@ subprojects {
     }
     val dokkaPlugin by configurations
     dependencies {
-        dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.8.20")
+        dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.9.0")
     }
 }

--- a/examples/versioning-multimodule-example/dokka/parentProject/build.gradle.kts
+++ b/examples/versioning-multimodule-example/dokka/parentProject/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.dokka.versioning.VersioningConfiguration
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.dokka:versioning-plugin:1.8.20")
+        classpath("org.jetbrains.dokka:versioning-plugin:1.9.0")
     }
 
     repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 
-kotlin = "1.8.20" # should match Gradle's embedded Kotlin version https://docs.gradle.org/current/userguide/compatibility.html#kotlin
-kotlin-dokka = "1.8.20"
-kotlinx-serialization = "1.5.1"
+kotlin = "1.9.0" # should match Gradle's embedded Kotlin version https://docs.gradle.org/current/userguide/compatibility.html#kotlin
+kotlin-dokka = "1.9.0"
+kotlinx-serialization = "1.6.0"
 
 kotest = "5.6.2"
 
 gradlePlugin-android = "8.0.2"
-gradlePlugin-dokkatoo = "1.5.0"
+gradlePlugin-dokkatoo = "1.6.0"
 gradlePlugin-gradlePublishPlugin = "1.2.1"
 gradlePlugin-bcvMu = "0.0.4"
 

--- a/modules/docs/build.gradle.kts
+++ b/modules/docs/build.gradle.kts
@@ -22,10 +22,6 @@ dokkatoo {
       "./images/logo-icon.svg",
     )
   }
-
-  versions {
-    jetbrainsDokka.set(libs.versions.kotlin.dokka)
-  }
 }
 
 tasks.dokkatooGeneratePublicationHtml {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-android-0/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-android-0/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-android-0/dokkatoo/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-android-0/dokkatoo/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("com.android.library") version "8.0.2"
-  kotlin("android") version "1.8.22"
+  kotlin("android") version "1.9.0"
   id("dev.adamko.dokkatoo") version "2.0.0-SNAPSHOT"
 }
 

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic-groovy/dokka/gradle.properties
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic-groovy/dokka/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic-groovy/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic-groovy/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokka/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokka/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.dokka:dokka-base:1.8.20")
+        classpath("org.jetbrains.dokka:dokka-base:1.9.0")
     }
 }
 
-version = "1.8.20-SNAPSHOT"
+version = "1.9.0-SNAPSHOT"
 
 apply(from = "./template.root.gradle.kts")
 

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokka/gradle.properties
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokka/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-basic/dokkatoo/build.gradle.kts
@@ -2,11 +2,11 @@ import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
 import dev.adamko.dokkatoo.dokka.plugins.DokkaHtmlPluginParameters
 
 plugins {
-  kotlin("jvm") version "1.8.22"
+  kotlin("jvm") version "1.9.0"
   id("dev.adamko.dokkatoo") version "2.0.0-SNAPSHOT"
 }
 
-version = "1.8.20-SNAPSHOT"
+version = "1.9.0-SNAPSHOT"
 
 dependencies {
   testImplementation(kotlin("test-junit"))

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-collector-0/dokka/gradle.properties
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-collector-0/dokka/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-collector-0/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-collector-0/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-js-ir-0/dokka/gradle.properties
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-js-ir-0/dokka/gradle.properties
@@ -1,2 +1,2 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0
 react_version=18.2.0-pre.467

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-js-ir-0/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-js-ir-0/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-0/dokka/gradle.properties
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-0/dokka/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-0/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-0/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-1/dokka/gradle.properties
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-1/dokka/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-1/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-1/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-versioning-0/dokka/gradle.properties
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-versioning-0/dokka/gradle.properties
@@ -1,2 +1,2 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0
 

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-versioning-0/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-multimodule-versioning-0/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-multiplatform-0/dokka/gradle.properties
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-multiplatform-0/dokka/gradle.properties
@@ -1,4 +1,4 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0
 #these flags are enabled by default since 1.6.20.
 #remove when this test is executed with Kotlin >= 1.6.20
 kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-multiplatform-0/dokka/template.settings.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-multiplatform-0/dokka/template.settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.dokka") {
-                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
             }
 
             if (requested.id.id == "com.android.library") {

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
@@ -136,7 +136,7 @@ private fun initDokkaProject(
 
     gradleProperties = gradleProperties
       .replace(
-        "dokka_it_android_gradle_plugin_version=4.1.3",
+        "dokka_it_android_gradle_plugin_version=4.2.2",
         "dokka_it_android_gradle_plugin_version=8.0.2",
       )
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -155,11 +155,9 @@ abstract class DokkatooFormatPlugin(
         version.map { v -> create("$this:$v") }
 
       with(dokkatooExtension.versions) {
-        dokkaPlugin(dokka("dokka-analysis"))
+        dokkaPlugin(dokka("analysis-kotlin-descriptors"))
         dokkaPlugin(dokka("templating-plugin"))
         dokkaPlugin(dokka("dokka-base"))
-        dokkaPlugin(dokka("kotlin-analysis-intellij"))
-        dokkaPlugin(dokka("kotlin-analysis-compiler"))
 //        dokkaPlugin(dokka("all-modules-page-plugin"))
 
         dokkaPlugin("org.jetbrains.kotlinx:kotlinx-html" version kotlinxHtml)


### PR DESCRIPTION
* Update Kotlin Analysis dependencies to use new single dependency (analysis-kotlin-descriptors)
* Dependency updates:
  * Update Kotlin from 1.8.20 to 1.9.0
  * Update Dokka from 1.8.20 to 1.9.0
  * Update Kotlin Serialization from 1.5.1 to 1.6.0
  * Update internal Dokkatoo from 1.5.0 to 1.6.0

Resolves #117

---

Let me know if the examples should be updated as well