### PR TITLE
add additional logging for KotlinProjectExtension failures

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/logUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/logUtils.kt
@@ -1,0 +1,8 @@
+package dev.adamko.dokkatoo.internal
+
+import org.gradle.api.logging.Logger
+
+/** Only evaluate and log [msg] when [Logger.isWarnEnabled] is `true`. */
+internal fun Logger.warn(msg: () -> String) {
+  if (isWarnEnabled) warn(msg())
+}


### PR DESCRIPTION
Part of #123 

Add some additional logging when KotlinProjectExtension cannot be retrieved (due to weird Gradle issues - see https://github.com/gradle/gradle/issues/27218)