### PR TITLE
automatically add version for Dokka dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ dokkatoo {
     suppressObviousFunctions.set(true)
     suppressObviousFunctions.set(false)
   }
+  // The default versions that Dokkatoo uses can be overridden:
+  versions {
+    jetbrainsDokka.set("1.9.10")
+  }
 }
 ```
 
@@ -156,12 +160,9 @@ dependencies {
   dokkatoo(projects(":subproject-hello"))
   dokkatoo(projects(":subproject-world"))
 
-  // This is required at the moment, see https://github.com/adamko-dev/dokkatoo/issues/14
-  dokkatooPluginHtml(
-    dokkatoo.versions.jetbrainsDokka.map { dokkaVersion ->
-      "org.jetbrains.dokka:all-modules-page-plugin:$dokkaVersion"
-    }
-  )
+  // A dependency on all-modules-page-plugin is required at the moment, see https://github.com/adamko-dev/dokkatoo/issues/14
+  // A version is not required, Dokkatoo will automatically add one.
+  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ idea {
       addAll(
         projectDir.walk().filter { file ->
           excludedDirs.any {
-            file.invariantSeparatorsPath.endsWith(it)
+            file.invariantSeparatorsPath.endsWith("/$it")
           }
         }
       )

--- a/examples/multimodule-example/dokkatoo/parentProject/build.gradle.kts
+++ b/examples/multimodule-example/dokkatoo/parentProject/build.gradle.kts
@@ -6,16 +6,9 @@ plugins {
 dependencies {
   dokkatoo(project(":parentProject:childProjectA"))
   dokkatoo(project(":parentProject:childProjectB"))
-  dokkatooPluginHtml(
-    dokkatoo.versions.jetbrainsDokka.map { dokkaVersion ->
-      "org.jetbrains.dokka:all-modules-page-plugin:$dokkaVersion"
-    }
-  )
-  dokkatooPluginHtml(
-    dokkatoo.versions.jetbrainsDokka.map { dokkaVersion ->
-      "org.jetbrains.dokka:templating-plugin:$dokkaVersion"
-    }
-  )
+
+  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin")
+  dokkatooPluginHtml("org.jetbrains.dokka:templating-plugin")
 }
 
 dokkatoo {

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -315,11 +315,15 @@ public final class dev/adamko/dokkatoo/dokka/plugins/PluginConfigValue$Values : 
 }
 
 public abstract class dev/adamko/dokkatoo/formats/DokkatooFormatPlugin : org/gradle/api/Plugin {
+	public static final field Companion Ldev/adamko/dokkatoo/formats/DokkatooFormatPlugin$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/Project;)V
 	public fun configure (Ldev/adamko/dokkatoo/formats/DokkatooFormatPlugin$DokkatooFormatPluginContext;)V
 	public final fun getFormatName ()Ljava/lang/String;
+}
+
+public final class dev/adamko/dokkatoo/formats/DokkatooFormatPlugin$Companion {
 }
 
 public final class dev/adamko/dokkatoo/formats/DokkatooFormatTasks$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatDependencyContainers.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatDependencyContainers.kt
@@ -90,7 +90,7 @@ class DokkatooFormatDependencyContainers(
    *
    * Users can add plugins to this dependency.
    *
-   * Should not contain runtime dependencies.
+   * Should not contain runtime dependencies - use [dokkaGeneratorClasspath].
    */
   val dokkaPluginsClasspath: NamedDomainObjectProvider<Configuration> =
     project.configurations.register(dependencyContainerNames.dokkaPluginsClasspath) {

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -427,11 +427,7 @@ private fun initDokkatooProject(
       |dependencies {
       |  dokkatoo(project(":subproject-hello"))
       |  dokkatoo(project(":subproject-goodbye"))
-      |  dokkatooPluginHtml(
-      |    dokkatoo.versions.jetbrainsDokka.map { dokkaVersion ->
-      |      "org.jetbrains.dokka:all-modules-page-plugin:${'$'}dokkaVersion"
-      |    }
-      |  )
+      |  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin")
       |}
       |
     """.trimMargin()

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
@@ -105,11 +105,7 @@ private fun initDokkatooProject(
       |}
       |
       |dependencies {
-      |  dokkatooPluginHtml(
-      |    dokkatoo.versions.jetbrainsDokka.map { dokkaVersion ->
-      |      "org.jetbrains.dokka:all-modules-page-plugin:${'$'}dokkaVersion"
-      |    }
-      |  )
+      |  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin")
       |}
       |
       |tasks.withType<dev.adamko.dokkatoo.tasks.LogHtmlPublicationLinkTask>().configureEach {


### PR DESCRIPTION
Automatically add a version for Dokka dependencies when one is missing.

This helps with #14.