### PR TITLE
Automatically add all-modules-page-plugin when aggregating HTML modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ dependencies {
   dokkatoo(projects(":subproject-hello"))
   dokkatoo(projects(":subproject-world"))
 
-  // A dependency on all-modules-page-plugin is required at the moment, see https://github.com/adamko-dev/dokkatoo/issues/14
-  // If using Dokkatoo v2.1.0+ version is not required, Dokkatoo will automatically add one.
-  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin") 
+  // If using Dokkatoo v2.1.0+ a dependency on all-modules-page-plugin is no longer required,
+  // see https://github.com/adamko-dev/dokkatoo/issues/14
+  //dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin") 
 
-  // Earlier versions of Dokkatoo must add a dependency:
+  // Earlier versions of Dokkatoo must manually add a dependency:
   dokkatooPluginHtml(
      dokkatoo.versions.jetbrainsDokka.map { dokkaVersion ->
         "org.jetbrains.dokka:all-modules-page-plugin:$dokkaVersion"

--- a/examples/multimodule-example/dokkatoo/parentProject/build.gradle.kts
+++ b/examples/multimodule-example/dokkatoo/parentProject/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
   dokkatoo(project(":parentProject:childProjectA"))
   dokkatoo(project(":parentProject:childProjectB"))
 
-  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin")
   dokkatooPluginHtml("org.jetbrains.dokka:templating-plugin")
 }
 

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -336,6 +336,7 @@ public abstract class dev/adamko/dokkatoo/formats/DokkatooGfmPlugin : dev/adamko
 }
 
 public abstract class dev/adamko/dokkatoo/formats/DokkatooHtmlPlugin : dev/adamko/dokkatoo/formats/DokkatooFormatPlugin {
+	public static final field Companion Ldev/adamko/dokkatoo/formats/DokkatooHtmlPlugin$Companion;
 	public fun configure (Ldev/adamko/dokkatoo/formats/DokkatooFormatPlugin$DokkatooFormatPluginContext;)V
 }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatDependencyContainers.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatDependencyContainers.kt
@@ -36,7 +36,7 @@ import org.gradle.kotlin.dsl.*
 @DokkatooInternalApi
 class DokkatooFormatDependencyContainers(
   private val formatName: String,
-  dokkatooConsumer: NamedDomainObjectProvider<Configuration>,
+  val dokkatooConsumer: NamedDomainObjectProvider<Configuration>,
   project: Project,
 ) {
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -95,6 +95,7 @@ abstract class DokkatooFormatPlugin(
         project = target,
         dokkatooExtension = dokkatooExtension,
         dokkatooTasks = dokkatooTasks,
+        dependencyContainers = dependencyContainers,
         formatName = formatName,
       )
 
@@ -141,6 +142,7 @@ abstract class DokkatooFormatPlugin(
     val project: Project,
     val dokkatooExtension: DokkatooExtension,
     val dokkatooTasks: DokkatooFormatTasks,
+    val dependencyContainers: DokkatooFormatDependencyContainers,
     formatName: String,
   ) {
     private val dependencyContainerNames = DokkatooBasePlugin.DependencyContainerNames(formatName)
@@ -183,7 +185,7 @@ abstract class DokkatooFormatPlugin(
         dokkaPlugin(dokka("analysis-kotlin-descriptors"))
         dokkaPlugin(dokka("templating-plugin"))
         dokkaPlugin(dokka("dokka-base"))
-//        dokkaPlugin(dokka("all-modules-page-plugin"))
+        //dokkaPlugin(dokka("all-modules-page-plugin"))
 
         dokkaPlugin("org.jetbrains.kotlinx:kotlinx-html" version kotlinxHtml)
         dokkaPlugin("org.freemarker:freemarker" version freemarker)

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -427,7 +427,6 @@ private fun initDokkatooProject(
       |dependencies {
       |  dokkatoo(project(":subproject-hello"))
       |  dokkatoo(project(":subproject-goodbye"))
-      |  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin")
       |}
       |
     """.trimMargin()

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
@@ -105,7 +105,6 @@ private fun initDokkatooProject(
       |}
       |
       |dependencies {
-      |  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin")
       |}
       |
       |tasks.withType<dev.adamko.dokkatoo.tasks.LogHtmlPublicationLinkTask>().configureEach {


### PR DESCRIPTION
Fix #14 

Automatically add a dependency on all-modules-page-plugin if the HTML generation is combining subprojects.

This is pretty hacky, and while I think there's probably a better way to do it in Gradle, unfortunately Gradle's tools are so buggy and poorly documented that this is next the best thing.