### PR TITLE
Add option to toggle Dokka Generator Worker API isolation

### DIFF
--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -17,6 +17,11 @@ public final class dev/adamko/dokkatoo/DokkatooBasePlugin$inlined$sam$i$org_grad
 }
 
 public abstract class dev/adamko/dokkatoo/DokkatooExtension : java/io/Serializable, org/gradle/api/plugins/ExtensionAware {
+	public final fun ClassLoaderIsolation (Lkotlin/jvm/functions/Function1;)Ldev/adamko/dokkatoo/workers/ClassLoaderIsolation;
+	public static synthetic fun ClassLoaderIsolation$default (Ldev/adamko/dokkatoo/DokkatooExtension;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/adamko/dokkatoo/workers/ClassLoaderIsolation;
+	public final fun ProcessIsolation (Lkotlin/jvm/functions/Function1;)Ldev/adamko/dokkatoo/workers/ProcessIsolation;
+	public static synthetic fun ProcessIsolation$default (Ldev/adamko/dokkatoo/DokkatooExtension;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/adamko/dokkatoo/workers/ProcessIsolation;
+	public abstract fun getDokkaGeneratorIsolation ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDokkatooCacheDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getDokkatooConfigurationsDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getDokkatooModuleDirectory ()Lorg/gradle/api/file/DirectoryProperty;
@@ -357,10 +362,6 @@ public abstract interface annotation class dev/adamko/dokkatoo/internal/Dokkatoo
 }
 
 public abstract class dev/adamko/dokkatoo/tasks/DokkatooGenerateTask : dev/adamko/dokkatoo/tasks/DokkatooTask {
-	public final fun ClassLoaderIsolation (Lkotlin/jvm/functions/Function1;)Ldev/adamko/dokkatoo/workers/ClassLoaderIsolation;
-	public static synthetic fun ClassLoaderIsolation$default (Ldev/adamko/dokkatoo/tasks/DokkatooGenerateTask;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/adamko/dokkatoo/workers/ClassLoaderIsolation;
-	public final fun ProcessIsolation (Lkotlin/jvm/functions/Function1;)Ldev/adamko/dokkatoo/workers/ProcessIsolation;
-	public static synthetic fun ProcessIsolation$default (Ldev/adamko/dokkatoo/tasks/DokkatooGenerateTask;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/adamko/dokkatoo/workers/ProcessIsolation;
 	public abstract fun getCacheDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getGenerationType ()Lorg/gradle/api/provider/Property;
 	public final fun getGenerator ()Ldev/adamko/dokkatoo/dokka/parameters/DokkaGeneratorParametersSpec;

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -357,6 +357,10 @@ public abstract interface annotation class dev/adamko/dokkatoo/internal/Dokkatoo
 }
 
 public abstract class dev/adamko/dokkatoo/tasks/DokkatooGenerateTask : dev/adamko/dokkatoo/tasks/DokkatooTask {
+	public final fun ClassLoaderIsolation (Lkotlin/jvm/functions/Function1;)Ldev/adamko/dokkatoo/workers/ClassLoaderIsolation;
+	public static synthetic fun ClassLoaderIsolation$default (Ldev/adamko/dokkatoo/tasks/DokkatooGenerateTask;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/adamko/dokkatoo/workers/ClassLoaderIsolation;
+	public final fun ProcessIsolation (Lkotlin/jvm/functions/Function1;)Ldev/adamko/dokkatoo/workers/ProcessIsolation;
+	public static synthetic fun ProcessIsolation$default (Ldev/adamko/dokkatoo/tasks/DokkatooGenerateTask;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/adamko/dokkatoo/workers/ProcessIsolation;
 	public abstract fun getCacheDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getGenerationType ()Lorg/gradle/api/provider/Property;
 	public final fun getGenerator ()Ldev/adamko/dokkatoo/dokka/parameters/DokkaGeneratorParametersSpec;
@@ -364,6 +368,7 @@ public abstract class dev/adamko/dokkatoo/tasks/DokkatooGenerateTask : dev/adamk
 	public abstract fun getPublicationEnabled ()Lorg/gradle/api/provider/Property;
 	public abstract fun getRuntimeClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getWorkerDebugEnabled ()Lorg/gradle/api/provider/Property;
+	public abstract fun getWorkerIsolation ()Lorg/gradle/api/provider/Property;
 	public abstract fun getWorkerJvmArgs ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getWorkerLogFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getWorkerMaxHeapSize ()Lorg/gradle/api/provider/Property;
@@ -398,5 +403,22 @@ public abstract class dev/adamko/dokkatoo/tasks/LogHtmlPublicationLinkTask : dev
 }
 
 public final class dev/adamko/dokkatoo/tasks/LogHtmlPublicationLinkTask$Companion {
+}
+
+public abstract interface class dev/adamko/dokkatoo/workers/ClassLoaderIsolation : dev/adamko/dokkatoo/workers/WorkerIsolation {
+}
+
+public abstract interface class dev/adamko/dokkatoo/workers/ProcessIsolation : dev/adamko/dokkatoo/workers/WorkerIsolation {
+	public abstract fun getAllJvmArgs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
+	public abstract fun getDefaultCharacterEncoding ()Lorg/gradle/api/provider/Property;
+	public abstract fun getEnableAssertions ()Lorg/gradle/api/provider/Property;
+	public abstract fun getJvmArgs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getMaxHeapSize ()Lorg/gradle/api/provider/Property;
+	public abstract fun getMinHeapSize ()Lorg/gradle/api/provider/Property;
+	public abstract fun getSystemProperties ()Lorg/gradle/api/provider/MapProperty;
+}
+
+public abstract interface class dev/adamko/dokkatoo/workers/WorkerIsolation {
 }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -86,22 +86,28 @@ constructor(
       dokkaConfigurationJsonFile.convention(temporaryDir.resolve("dokka-configuration.json"))
 
       workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
-      workerIsolation.convention(dokkatooExtension.dokkaGeneratorIsolation.map { iso ->
-        when (iso) {
+      workerIsolation.convention(dokkatooExtension.dokkaGeneratorIsolation.map { src ->
+        when (src) {
           is ClassLoaderIsolation -> {}
           is ProcessIsolation     -> {
-            // Copy old properties, to maintain backwards compatibility.
+            // Complicated workaround to copy old properties, to maintain backwards compatibility.
             // Remove when the deprecated task properties are deleted.
-            @Suppress("DEPRECATION")
-            run {
-              iso.debug.convention(workerDebugEnabled)
-              iso.minHeapSize.convention(workerMinHeapSize)
-              iso.maxHeapSize.convention(workerMaxHeapSize)
-              iso.jvmArgs.convention(workerJvmArgs)
+            dokkatooExtension.ProcessIsolation {
+              @Suppress("DEPRECATION")
+              run {
+                debug.convention(workerDebugEnabled.orElse(src.debug))
+                enableAssertions.convention(src.enableAssertions)
+                minHeapSize.convention(workerMinHeapSize.orElse(src.minHeapSize))
+                maxHeapSize.convention(workerMaxHeapSize.orElse(src.maxHeapSize))
+                jvmArgs.convention(workerJvmArgs.orElse(src.jvmArgs))
+                allJvmArgs.convention(src.allJvmArgs)
+                defaultCharacterEncoding.convention(src.defaultCharacterEncoding)
+                systemProperties.convention(src.systemProperties)
+              }
             }
           }
         }
-        iso
+        src
       })
 
       publicationEnabled.convention(true)

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -85,7 +85,6 @@ constructor(
       workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
       dokkaConfigurationJsonFile.convention(temporaryDir.resolve("dokka-configuration.json"))
 
-      workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
       workerIsolation.convention(dokkatooExtension.dokkaGeneratorIsolation.map { src ->
         when (src) {
           is ClassLoaderIsolation -> {}

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -74,17 +74,7 @@ constructor(
 
     target.tasks.withType<DokkatooGenerateTask>().configureEach {
       cacheDirectory.convention(dokkatooExtension.dokkatooCacheDirectory)
-      workerDebugEnabled.convention(false)
       workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
-      workerJvmArgs.set(
-        listOf(
-          //"-XX:MaxMetaspaceSize=512m",
-          "-XX:+HeapDumpOnOutOfMemoryError",
-          "-XX:+AlwaysPreTouch", // https://github.com/gradle/gradle/issues/3093#issuecomment-387259298
-          //"-XX:StartFlightRecording=disk=true,name={path.drop(1).map { if (it.isLetterOrDigit()) it else '-' }.joinToString("")},dumponexit=true,duration=30s",
-          //"-XX:FlightRecorderOptions=repository=$baseDir/jfr,stackdepth=512",
-        )
-      )
       dokkaConfigurationJsonFile.convention(temporaryDir.resolve("dokka-configuration.json"))
     }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -87,7 +87,7 @@ constructor(
 
       workerIsolation.convention(dokkatooExtension.dokkaGeneratorIsolation.map { src ->
         when (src) {
-          is ClassLoaderIsolation -> {}
+          is ClassLoaderIsolation -> src
           is ProcessIsolation     -> {
             // Complicated workaround to copy old properties, to maintain backwards compatibility.
             // Remove when the deprecated task properties are deleted.
@@ -106,7 +106,6 @@ constructor(
             }
           }
         }
-        src
       })
 
       publicationEnabled.convention(true)

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -99,6 +99,22 @@ constructor(
       generator.dokkaSourceSets.configureDefaults(
         sourceSetScopeConvention = dokkatooExtension.sourceSetScopeDefault
       )
+
+      workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
+//      workerIsolation.convention(ProcessIsolation {
+//        debug.convention(false)
+//        jvmArgs.convention(
+//          listOf(
+//            //"-XX:MaxMetaspaceSize=512m",
+//            "-XX:+HeapDumpOnOutOfMemoryError",
+//            "-XX:+AlwaysPreTouch", // https://github.com/gradle/gradle/issues/3093#issuecomment-387259298
+//            //"-XX:StartFlightRecording=disk=true,name={path.drop(1).map { if (it.isLetterOrDigit()) it else '-' }.joinToString("")},dumponexit=true,duration=30s",
+//            //"-XX:FlightRecorderOptions=repository=$baseDir/jfr,stackdepth=512",
+//          )
+//        )
+//      })
+      // TODO setting classloader isolation causes many test failures due to metaspace limits.
+      workerIsolation.set(ClassLoaderIsolation())
     }
 
     dokkatooExtension.dokkatooSourceSets.configureDefaults(

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -72,12 +72,6 @@ constructor(
       sourceSetScopeConvention = dokkatooExtension.sourceSetScopeDefault
     )
 
-    target.tasks.withType<DokkatooGenerateTask>().configureEach {
-      cacheDirectory.convention(dokkatooExtension.dokkatooCacheDirectory)
-      workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
-      dokkaConfigurationJsonFile.convention(temporaryDir.resolve("dokka-configuration.json"))
-    }
-
     target.tasks.withType<DokkatooPrepareModuleDescriptorTask>().configureEach {
       moduleName.convention(dokkatooExtension.moduleName)
       includes.from(providers.provider { dokkatooExtension.dokkatooSourceSets.flatMap { it.includes } })
@@ -85,6 +79,23 @@ constructor(
     }
 
     target.tasks.withType<DokkatooGenerateTask>().configureEach {
+      cacheDirectory.convention(dokkatooExtension.dokkatooCacheDirectory)
+      workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
+      dokkaConfigurationJsonFile.convention(temporaryDir.resolve("dokka-configuration.json"))
+
+      workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
+      workerIsolation.convention(ProcessIsolation {
+        debug.convention(false)
+        jvmArgs.convention(
+          listOf(
+            //"-XX:MaxMetaspaceSize=512m",
+            "-XX:+HeapDumpOnOutOfMemoryError",
+            "-XX:+AlwaysPreTouch", // https://github.com/gradle/gradle/issues/3093#issuecomment-387259298
+            //"-XX:StartFlightRecording=disk=true,name={path.drop(1).map { if (it.isLetterOrDigit()) it else '-' }.joinToString("")},dumponexit=true,duration=30s",
+            //"-XX:FlightRecorderOptions=repository=$baseDir/jfr,stackdepth=512",
+          )
+        )
+      })
 
       publicationEnabled.convention(true)
       onlyIf("publication must be enabled") { publicationEnabled.getOrElse(true) }
@@ -99,22 +110,6 @@ constructor(
       generator.dokkaSourceSets.configureDefaults(
         sourceSetScopeConvention = dokkatooExtension.sourceSetScopeDefault
       )
-
-      workerLogFile.convention(temporaryDir.resolve("dokka-worker.log"))
-//      workerIsolation.convention(ProcessIsolation {
-//        debug.convention(false)
-//        jvmArgs.convention(
-//          listOf(
-//            //"-XX:MaxMetaspaceSize=512m",
-//            "-XX:+HeapDumpOnOutOfMemoryError",
-//            "-XX:+AlwaysPreTouch", // https://github.com/gradle/gradle/issues/3093#issuecomment-387259298
-//            //"-XX:StartFlightRecording=disk=true,name={path.drop(1).map { if (it.isLetterOrDigit()) it else '-' }.joinToString("")},dumponexit=true,duration=30s",
-//            //"-XX:FlightRecorderOptions=repository=$baseDir/jfr,stackdepth=512",
-//          )
-//        )
-//      })
-      // TODO setting classloader isolation causes many test failures due to metaspace limits.
-      workerIsolation.set(ClassLoaderIsolation())
     }
 
     dokkatooExtension.dokkatooSourceSets.configureDefaults(

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
@@ -3,6 +3,9 @@ package dev.adamko.dokkatoo
 import dev.adamko.dokkatoo.dokka.DokkaPublication
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
 import dev.adamko.dokkatoo.internal.*
+import dev.adamko.dokkatoo.workers.ClassLoaderIsolation
+import dev.adamko.dokkatoo.workers.ProcessIsolation
+import dev.adamko.dokkatoo.workers.WorkerIsolation
 import java.io.Serializable
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.DirectoryProperty
@@ -10,7 +13,9 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Nested
 import org.gradle.kotlin.dsl.*
+import org.gradle.workers.WorkerExecutor
 
 /**
  * Configure the behaviour of the [DokkatooBasePlugin].
@@ -18,7 +23,7 @@ import org.gradle.kotlin.dsl.*
 abstract class DokkatooExtension
 @DokkatooInternalApi
 constructor(
-  objects: ObjectFactory,
+  private val objects: ObjectFactory,
 ) : ExtensionAware, Serializable {
 
   /** Directory into which [DokkaPublication]s will be produced */
@@ -127,4 +132,52 @@ constructor(
 
     companion object
   }
+
+  /**
+   * Dokkatoo runs Dokka Generator in a separate
+   * [Gradle Worker](https://docs.gradle.org/8.5/userguide/worker_api.html).
+   *
+   * You can control whether Dokkatoo launches Dokka Generator in
+   * * a new process, using [ProcessIsolation],
+   * * or the current process with an isolated classpath, using [ClassLoaderIsolation].
+   *
+   * _Aside: Launching [without isolation][WorkerExecutor.noIsolation] is not an option, because
+   * running Dokka Generator **requires** an isolated classpath._
+   *
+   * ```kotlin
+   * dokkatoo {
+   *   // use the current Gradle process, but with an isolated classpath
+   *   workerIsolation = ClassLoaderIsolation()
+   *
+   *   // launch a new process, optionally controlling the standard JVM options
+   *   workerIsolation = ProcessIsolation {
+   *     minHeapSize = "2g" // increase minimum heap size
+   *     systemProperties.add("someCustomProperty", 123)
+   *   }
+   * }
+   * ```
+   *
+   * @see WorkerIsolation
+   * @see dev.adamko.dokkatoo.workers.ProcessIsolation
+   * @see dev.adamko.dokkatoo.workers.ClassLoaderIsolation
+   *
+   */
+  @get:Nested
+  abstract val dokkaGeneratorIsolation: Property<WorkerIsolation>
+
+  /**
+   * Create a new [ClassLoaderIsolation] options instance.
+   *
+   * The resulting options must be set into [dokkaGeneratorIsolation].
+   */
+  fun ClassLoaderIsolation(configure: ClassLoaderIsolation.() -> Unit = {}): ClassLoaderIsolation =
+    objects.newInstance<ClassLoaderIsolation>().apply(configure)
+
+  /**
+   * Create a new [ProcessIsolation] options.
+   *
+   * The resulting options instance must be set into [dokkaGeneratorIsolation].
+   */
+  fun ProcessIsolation(configure: ProcessIsolation.() -> Unit = {}): ProcessIsolation =
+    objects.newInstance<ProcessIsolation>().apply(configure)
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -72,20 +72,6 @@ constructor(
   @get:Nested
   val generator: DokkaGeneratorParametersSpec = objects.newInstance(pluginsConfiguration)
 
-  /** @see JavaForkOptions.getDebug */
-  @get:Input
-  abstract val workerDebugEnabled: Property<Boolean>
-  /** @see JavaForkOptions.getMinHeapSize */
-  @get:Input
-  @get:Optional
-  abstract val workerMinHeapSize: Property<String>
-  /** @see JavaForkOptions.getMaxHeapSize */
-  @get:Input
-  @get:Optional
-  abstract val workerMaxHeapSize: Property<String>
-  /** @see JavaForkOptions.jvmArgs */
-  @get:Input
-  abstract val workerJvmArgs: ListProperty<String>
   @get:Internal
   abstract val workerLogFile: RegularFileProperty
 
@@ -110,16 +96,8 @@ constructor(
 
     logger.info("DokkaGeneratorWorker runtimeClasspath: ${runtimeClasspath.asPath}")
 
-    val workQueue = workers.processIsolation {
+    val workQueue = workers.classLoaderIsolation {
       classpath.from(runtimeClasspath)
-      forkOptions {
-        defaultCharacterEncoding = "UTF-8"
-        minHeapSize = workerMinHeapSize.orNull
-        maxHeapSize = workerMaxHeapSize.orNull
-        enableAssertions = true
-        debug = workerDebugEnabled.get()
-        jvmArgs = workerJvmArgs.get()
-      }
     }
 
     workQueue.submit(DokkaGeneratorWorker::class) {

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -199,19 +199,19 @@ constructor(
   //region Deprecated Properties
   /** @see JavaForkOptions.getDebug */
   @get:Internal
-  @Deprecated("worker options were moved to `workerIsolation` property to allow for configuring worker isolation")
+  @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerDebugEnabled: Property<Boolean>
   /** @see JavaForkOptions.getMinHeapSize */
   @get:Internal
-  @Deprecated("worker options were moved to `workerIsolation` property to allow for configuring worker isolation")
+  @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerMinHeapSize: Property<String>
   /** @see JavaForkOptions.getMaxHeapSize */
   @get:Internal
-  @Deprecated("worker options were moved to `workerIsolation` property to allow for configuring worker isolation")
+  @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerMaxHeapSize: Property<String>
   /** @see JavaForkOptions.jvmArgs */
   @get:Internal
-  @Deprecated("worker options were moved to `workerIsolation` property to allow for configuring worker isolation")
+  @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerJvmArgs: ListProperty<String>
   //endregion
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -75,6 +75,35 @@ constructor(
   @get:Nested
   val generator: DokkaGeneratorParametersSpec = objects.newInstance(pluginsConfiguration)
 
+  /**
+   * Dokkatoo runs Dokka Generator in a separate
+   * [Gradle Worker](https://docs.gradle.org/8.5/userguide/worker_api.html).
+   *
+   * You can control whether Dokkatoo launches Dokka Generator in
+   * * a new process, using [ProcessIsolation],
+   * * or the current process with an isolated classpath, using [ClassLoaderIsolation].
+   *
+   * _Aside: Launching [without isolation][WorkerExecutor.noIsolation] is not an option, because
+   * Dokka **requires** an isolated classpath._
+   *
+   * ```kotlin
+   * dokkatoo {
+   *   // use the current Gradle process, but with an isolated classpath
+   *   workerIsolation = ClassLoaderIsolation()
+   *
+   *   // launch a new process, optionally controlling the standard JVM options
+   *   workerIsolation = ProcessIsolation {
+   *     minHeapSize = "2g" // increase minimum heap size
+   *     systemProperties.add("someCustomProperty", 123)
+   *   }
+   * }
+   * ```
+   *
+   * @see WorkerIsolation
+   * @see dev.adamko.dokkatoo.workers.ProcessIsolation
+   * @see dev.adamko.dokkatoo.workers.ClassLoaderIsolation
+   *
+   */
   @get:Nested
   abstract val workerIsolation: Property<WorkerIsolation>
 
@@ -89,7 +118,7 @@ constructor(
   /**
    * Create a new [ProcessIsolation] options.
    *
-   * The resulting options must be set into [workerIsolation].
+   * The resulting options instance must be set into [workerIsolation].
    */
   fun ProcessIsolation(configure: ProcessIsolation.() -> Unit = {}): ProcessIsolation =
     objects.newInstance<ProcessIsolation>().apply {
@@ -214,19 +243,19 @@ constructor(
   //region Deprecated Properties
   /** @see JavaForkOptions.getDebug */
   @get:Internal
-  @Deprecated("moved to TODO") // TODO
+  @Deprecated("worker options were moved to `workerIsolation` property to allow for configuring worker isolation")
   abstract val workerDebugEnabled: Property<Boolean>
   /** @see JavaForkOptions.getMinHeapSize */
   @get:Internal
-  @Deprecated("moved to TODO") // TODO
+  @Deprecated("worker options were moved to `workerIsolation` property to allow for configuring worker isolation")
   abstract val workerMinHeapSize: Property<String>
   /** @see JavaForkOptions.getMaxHeapSize */
   @get:Internal
-  @Deprecated("moved to TODO") // TODO
+  @Deprecated("worker options were moved to `workerIsolation` property to allow for configuring worker isolation")
   abstract val workerMaxHeapSize: Property<String>
   /** @see JavaForkOptions.jvmArgs */
   @get:Internal
-  @Deprecated("moved to TODO") // TODO
+  @Deprecated("worker options were moved to `workerIsolation` property to allow for configuring worker isolation")
   abstract val workerJvmArgs: ListProperty<String>
   //endregion
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/workers/WorkerIsolationProperties.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/workers/WorkerIsolationProperties.kt
@@ -1,0 +1,76 @@
+package dev.adamko.dokkatoo.workers
+
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.process.JavaForkOptions
+
+
+/**
+ * Configure how a Gradle Worker is created using [org.gradle.workers.WorkerExecutor].
+ */
+sealed interface WorkerIsolation
+
+
+/**
+ * Create a Worker in the current Gradle process, with an isolated classpath.
+ *
+ * Presently there are no options to configure the behaviour of a classloader-isolated worker.
+ *
+ * @see org.gradle.workers.ClassLoaderWorkerSpec
+ */
+interface ClassLoaderIsolation : WorkerIsolation {
+  // no options yet...
+}
+
+
+/**
+ * Create a Worker using process isolation.
+ *
+ * Gradle will launch new Java process specifically for Dokka.
+ *
+ * @see org.gradle.workers.ProcessWorkerSpec
+ */
+interface ProcessIsolation : WorkerIsolation {
+  /** @see JavaForkOptions.setDebug */
+  @get:Input
+  @get:Optional
+  val debug: Property<Boolean>
+
+  /** @see JavaForkOptions.setEnableAssertions */
+  @get:Input
+  @get:Optional
+  val enableAssertions: Property<Boolean>
+
+  /** @see JavaForkOptions.setMinHeapSize */
+  @get:Input
+  @get:Optional
+  val minHeapSize: Property<String>
+
+  /** @see JavaForkOptions.setMaxHeapSize */
+  @get:Input
+  @get:Optional
+  val maxHeapSize: Property<String>
+
+  /** @see JavaForkOptions.setJvmArgs */
+  @get:Input
+  @get:Optional
+  val jvmArgs: ListProperty<String>
+
+  /** @see JavaForkOptions.setAllJvmArgs */
+  @get:Input
+  @get:Optional
+  val allJvmArgs: ListProperty<String>
+
+  /** @see JavaForkOptions.setDefaultCharacterEncoding */
+  @get:Input
+  @get:Optional
+  val defaultCharacterEncoding: Property<String>
+
+  /** @see JavaForkOptions.setSystemProperties */
+  @get:Input
+  @get:Optional
+  val systemProperties: MapProperty<String, Any>
+}

--- a/modules/dokkatoo-plugin/src/main/kotlin/workers/WorkerIsolationProperties.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/workers/WorkerIsolationProperties.kt
@@ -6,20 +6,26 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.process.JavaForkOptions
+import org.gradle.workers.WorkerExecutor
 
 
 /**
  * Configure how a Gradle Worker is created using [org.gradle.workers.WorkerExecutor].
+ *
+ * @see WorkerExecutor.classLoaderIsolation
+ * @see WorkerExecutor.processIsolation
  */
 sealed interface WorkerIsolation
 
 
 /**
- * Create a Worker in the current Gradle process, with an isolated classpath.
+ * Execute a Worker in the current Gradle process, with an
+ * [isolated classpath][WorkerExecutor.classLoaderIsolation].
  *
  * Presently there are no options to configure the behaviour of a classloader-isolated worker.
  *
  * @see org.gradle.workers.ClassLoaderWorkerSpec
+ * @see WorkerExecutor.classLoaderIsolation
  */
 interface ClassLoaderIsolation : WorkerIsolation {
   // no options yet...
@@ -27,11 +33,14 @@ interface ClassLoaderIsolation : WorkerIsolation {
 
 
 /**
- * Create a Worker using process isolation.
+ * Create a Worker using [process isolation][WorkerExecutor.processIsolation].
  *
- * Gradle will launch new Java process specifically for Dokka.
+ * Gradle will launch
+ * [new Worker Daemon](https://docs.gradle.org/8.5/userguide/worker_api.html#creating_a_worker_daemon)
+ * re-using it across builds.
  *
  * @see org.gradle.workers.ProcessWorkerSpec
+ * @see WorkerExecutor.processIsolation
  */
 interface ProcessIsolation : WorkerIsolation {
   /** @see JavaForkOptions.setDebug */


### PR DESCRIPTION
I have this locally for testing so opening the PR while I'm on this. Feel free to close if you think process isolation is better.

Reasons I like classloader isolation are:

* I only need to monitor one JVM. In my build I had to bump the fork `Xmx` to > 2GB when my main build already has 8GB so theorically means the build could use 10GB or so. 
* It's easier to debug (no need to find the daemon and hook the debugger there)
* Might be a bit faster too? 

If the worker leaks then it becomes a problem but better fix the leaks? 