### PR TITLE
Attempt at making tasks build cache relocatable

### DIFF
--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -362,6 +362,7 @@ public abstract class dev/adamko/dokkatoo/tasks/DokkatooGenerateTask : dev/adamk
 	public final fun getGenerator ()Ldev/adamko/dokkatoo/dokka/parameters/DokkaGeneratorParametersSpec;
 	public abstract fun getOutputDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getPublicationEnabled ()Lorg/gradle/api/provider/Property;
+	public abstract fun getRootDirectory ()Lorg/gradle/api/provider/Property;
 	public abstract fun getRuntimeClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getWorkerDebugEnabled ()Lorg/gradle/api/provider/Property;
 	public abstract fun getWorkerJvmArgs ()Lorg/gradle/api/provider/ListProperty;
@@ -379,10 +380,11 @@ public final class dev/adamko/dokkatoo/tasks/DokkatooGenerateTask$GenerationType
 
 public abstract class dev/adamko/dokkatoo/tasks/DokkatooPrepareModuleDescriptorTask : dev/adamko/dokkatoo/tasks/DokkatooTask {
 	public abstract fun getDokkaModuleDescriptorJson ()Lorg/gradle/api/file/RegularFileProperty;
-	public abstract fun getIncludes ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getModuleDirectory ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getIncludes ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getModuleDirectory ()Lorg/gradle/api/provider/Property;
 	public abstract fun getModuleName ()Lorg/gradle/api/provider/Property;
 	public abstract fun getModulePath ()Lorg/gradle/api/provider/Property;
+	public abstract fun getRootDirectory ()Lorg/gradle/api/provider/Property;
 }
 
 public abstract class dev/adamko/dokkatoo/tasks/DokkatooTask : org/gradle/api/DefaultTask {

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -89,8 +89,9 @@ constructor(
     }
 
     target.tasks.withType<DokkatooPrepareModuleDescriptorTask>().configureEach {
+      val rootDirectoryFile = project.rootProject.rootDir
       moduleName.convention(dokkatooExtension.moduleName)
-      includes.from(providers.provider { dokkatooExtension.dokkatooSourceSets.flatMap { it.includes } })
+      includes.addAll(providers.provider { dokkatooExtension.dokkatooSourceSets.flatMap { it.includes.map { it.relativeTo(rootDirectoryFile).path } } })
       modulePath.convention(dokkatooExtension.modulePath)
     }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaParametersKxs.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/DokkaParametersKxs.kt
@@ -7,6 +7,7 @@ package dev.adamko.dokkatoo.dokka.parameters
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import java.io.File
 import java.nio.file.Paths
+import kotlin.io.path.Path
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -42,23 +43,29 @@ data class DokkaModuleDescriptionKxs(
   /** @see DokkaConfiguration.DokkaModuleDescription.name */
   val name: String,
   /**
-   * Location of the Dokka Module directory for a subproject.
+   * Location of the Dokka Module directory for a subproject, relative to the rootProject directory.
    *
    * @see DokkaConfiguration.DokkaModuleDescription.sourceOutputDirectory
    */
-  val sourceOutputDirectory: File,
-  /** @see DokkaConfiguration.DokkaModuleDescription.includes */
-  val includes: Set<File>,
+  val sourceOutputDirectory: String,
+  /**
+   * Location of the includes, relative to the rootProject directory.
+   *
+   * @see DokkaConfiguration.DokkaModuleDescription.includes
+   */
+  val includes: Set<String>,
   /** @see [org.gradle.api.Project.getPath] */
   val modulePath: String,
 ) {
-  internal fun convert() =
-    DokkaModuleDescriptionImpl(
+  internal fun convert(rootDirectory: String): DokkaModuleDescriptionImpl {
+    val rootPath = Path(rootDirectory)
+    return DokkaModuleDescriptionImpl(
       name = name,
       relativePathToOutputDirectory = File(modulePath.removePrefix(":").replace(':', '/')),
-      includes = includes,
-      sourceOutputDirectory = sourceOutputDirectory,
+      includes = includes.map { rootPath.resolve(it).normalize().toFile() }.toSet(),
+      sourceOutputDirectory = rootPath.resolve(sourceOutputDirectory).normalize().toFile(),
     )
+  }
 }
 
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/builders/DokkaParametersBuilder.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/parameters/builders/DokkaParametersBuilder.kt
@@ -27,6 +27,7 @@ internal object DokkaParametersBuilder {
     modules: List<DokkaModuleDescriptionKxs>,
     outputDirectory: File,
     cacheDirectory: File? = null,
+    rootDirectory: String
   ): DokkaConfiguration {
     val moduleName = spec.moduleName.get()
     val moduleVersion = spec.moduleVersion.orNull?.takeIf { it != Project.DEFAULT_VERSION }
@@ -50,7 +51,7 @@ internal object DokkaParametersBuilder {
       sourceSets = sourceSets,
       pluginsClasspath = pluginsClasspath,
       pluginsConfiguration = pluginsConfiguration.map(::build),
-      modules = modules.map(DokkaModuleDescriptionKxs::convert),
+      modules = modules.map{ it.convert(rootDirectory) },
 //      modules = modules.map {
 //        it.convert(
 //          moduleDescriptionFiles.get(it.name)

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatTasks.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatTasks.kt
@@ -58,6 +58,7 @@ class DokkatooFormatTasks(
   ).configuring task@{
     description = "Executes the Dokka Generator, generating the $formatName publication"
     generationType.set(DokkatooGenerateTask.GenerationType.PUBLICATION)
+    rootDirectory.set(project.rootProject.rootDir.absolutePath)
 
     outputDirectory.convention(dokkatooExtension.dokkatooPublicationDirectory.dir(formatName))
 
@@ -81,6 +82,7 @@ class DokkatooFormatTasks(
   ).configuring task@{
     description = "Executes the Dokka Generator, generating a $formatName module"
     generationType.set(DokkatooGenerateTask.GenerationType.MODULE)
+    rootDirectory.set(project.rootProject.rootDir.absolutePath)
 
     outputDirectory.convention(dokkatooExtension.dokkatooModuleDirectory.dir(formatName))
 
@@ -91,11 +93,14 @@ class DokkatooFormatTasks(
     taskNames.prepareModuleDescriptor
   ) task@{
     description = "Prepares the Dokka Module Descriptor for $formatName"
-    includes.from(publication.includes)
+    val rootDirectoryFile = project.rootProject.rootDir
+    rootDirectory.set(rootDirectoryFile.absolutePath)
+
+    includes.addAll(publication.includes.map { it.relativeTo(rootDirectoryFile).path })
     dokkaModuleDescriptorJson.convention(
       dokkatooExtension.dokkatooConfigurationsDirectory.file("$formatName/module_descriptor.json")
     )
-    moduleDirectory.set(generateModule.flatMap { it.outputDirectory })
+    moduleDirectory.set(generateModule.flatMap { it.outputDirectory.asFile.map { it.relativeTo(rootDirectoryFile).path } })
 
 //      dokkaSourceSets.addAllLater(providers.provider { dokkatooExtension.dokkatooSourceSets })
 //      dokkaSourceSets.configureEach {

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -97,6 +97,9 @@ constructor(
   @get:Internal
   abstract val dokkaConfigurationJsonFile: RegularFileProperty
 
+  @get:Internal
+  abstract val rootDirectory: Property<String>
+
   enum class GenerationType {
     MODULE,
     PUBLICATION,
@@ -165,6 +168,7 @@ constructor(
       outputDirectory = outputDirectory,
       modules = dokkaModuleDescriptors,
       cacheDirectory = cacheDirectory.asFile.orNull,
+      rootDirectory = rootDirectory.get(),
     )
   }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooPrepareModuleDescriptorTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooPrepareModuleDescriptorTask.kt
@@ -6,6 +6,7 @@ import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import javax.inject.Inject
 import kotlinx.serialization.encodeToString
 import org.gradle.api.file.*
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
@@ -24,26 +25,26 @@ constructor() : DokkatooTask() {
   @get:OutputFile
   abstract val dokkaModuleDescriptorJson: RegularFileProperty
 
+  @get:Internal
+  abstract val rootDirectory: Property<String>
+
   @get:Input
   abstract val moduleName: Property<String>
 
   @get:Input
   abstract val modulePath: Property<String>
 
-  @get:InputDirectory
-  @get:PathSensitive(RELATIVE)
-  abstract val moduleDirectory: DirectoryProperty
+  @get:Input
+  abstract val moduleDirectory: Property<String>
 
-  @get:InputFiles
-  @get:Optional
-  @get:PathSensitive(RELATIVE)
-  abstract val includes: ConfigurableFileCollection
+  @get:Input
+  abstract val includes: ListProperty<String>
 
   @TaskAction
   internal fun generateModuleConfiguration() {
     val moduleName = moduleName.get()
-    val moduleDirectory = moduleDirectory.asFile.get()
-    val includes = includes.files
+    val moduleDirectory = moduleDirectory.get()
+    val includes = includes.get().toSet()
     val modulePath = modulePath.get()
 
     val moduleDesc = DokkaModuleDescriptionKxs(


### PR DESCRIPTION
Use `rootProject.rootDir` as a base for all paths. Your typical `module_descriptor.json` is now like:

```json
{
  "name": "apollo-annotations",
  "sourceOutputDirectory": "libraries/apollo-annotations/build/dokka-module/html",
  "includes": [
    "libraries/apollo-annotations/README.md"
  ],
  "modulePath": "apollo-annotations"
}
```

Note: this will break if includes are specified in a fixed position and/or if trying to create a publication across several builds (included builds, maven published modules, etc...) but that's a problem for another day... 😄.