### PR TITLE
refactor how Android projects are handled

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ ktor = "2.3.7"
 
 kotest = "5.8.0"
 
-#gradlePlugin-android = "8.2.0"
 gradlePlugin-android = "8.0.2"
 gradlePlugin-dokkatoo = "2.1.0-SNAPSHOT"
 gradlePlugin-gradlePublishPlugin = "1.2.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ ktor = "2.3.7"
 
 kotest = "5.8.0"
 
+#gradlePlugin-android = "8.2.0"
 gradlePlugin-android = "8.0.2"
 gradlePlugin-dokkatoo = "2.1.0-SNAPSHOT"
 gradlePlugin-gradlePublishPlugin = "1.2.1"

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -41,11 +41,12 @@ dependencies {
 }
 
 kotlin {
-  target {
-    compilations.configureEach {
-      compilerOptions.configure {
-        freeCompilerArgs.addAll(
-          "-opt-in=dev.adamko.dokkatoo.internal.DokkatooInternalApi",
+  sourceSets {
+    configureEach {
+      compilerOptions {
+        optIn.addAll(
+          "dev.adamko.dokkatoo.internal.DokkatooInternalApi",
+          "kotlin.io.path.ExperimentalPathApi",
         )
       }
     }

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-android-0/dokkatoo/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-android-0/dokkatoo/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("com.android.library") version "8.0.2"
-//  id("com.android.library") version "8.2.1"
   kotlin("android") version "1.9.0"
   id("dev.adamko.dokkatoo") version "2.1.0-SNAPSHOT"
 }
@@ -9,7 +8,6 @@ android {
   namespace = "org.jetbrains.dokka.it.android"
   defaultConfig {
     minSdkVersion(21)
-//    minSdk = 21
     setCompileSdkVersion(29)
   }
 }

--- a/modules/dokkatoo-plugin-integration-tests/projects/it-android-0/dokkatoo/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/projects/it-android-0/dokkatoo/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("com.android.library") version "8.0.2"
+//  id("com.android.library") version "8.2.1"
   kotlin("android") version "1.9.0"
   id("dev.adamko.dokkatoo") version "2.1.0-SNAPSHOT"
 }
@@ -8,6 +9,7 @@ android {
   namespace = "org.jetbrains.dokka.it.android"
   defaultConfig {
     minSdkVersion(21)
+//    minSdk = 21
     setCompileSdkVersion(29)
   }
 }
@@ -24,9 +26,6 @@ tasks.withType<dev.adamko.dokkatoo.tasks.DokkatooGenerateTask>().configureEach {
   // So, forcibly rename the SourceSetId.
 
   generator.dokkaSourceSets.configureEach {
-    // sourceSetScope renaming is fine, I'm not worried about it. The default comes from the
-    // Gradle Task name, so a name difference doesn't matter.
-    // We can just manually force the Dokkatoo name to match Dokka.
     sourceSetScope.set(":dokkaHtml")
   }
 }

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/KotlinMultiplatformExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/KotlinMultiplatformExampleTest.kt
@@ -128,7 +128,7 @@ class KotlinMultiplatformExampleTest : FunSpec({
             output shouldContainAll listOf(
               "> Task :dokkatooGeneratePublicationHtml UP-TO-DATE",
               "BUILD SUCCESSFUL",
-              "2 actionable tasks: 2 up-to-date",
+              "1 actionable task: 1 up-to-date",
             )
             withClue("Dokka Generator should not be triggered, so check it doesn't log anything") {
               output shouldNotContain "Generation completed successfully"

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
@@ -98,64 +98,64 @@ class AndroidProjectIntegrationTest : FunSpec({
 
         actualFileTree shouldBe /* language=text */ """
           html/
-          ├── index.html
           ├── images/
-          │   ├── copy-icon.svg
-          │   ├── footer-go-to-link.svg
-          │   ├── logo-icon.svg
           │   ├── nav-icons/
-          │   │   ├── function.svg
-          │   │   ├── interface.svg
-          │   │   ├── enum.svg
-          │   │   ├── typealias-kotlin.svg
-          │   │   ├── field-value.svg
+          │   │   ├── abstract-class-kotlin.svg
           │   │   ├── abstract-class.svg
+          │   │   ├── annotation-kotlin.svg
+          │   │   ├── annotation.svg
           │   │   ├── class-kotlin.svg
           │   │   ├── class.svg
-          │   │   ├── exception-class.svg
-          │   │   ├── annotation-kotlin.svg
-          │   │   ├── field-variable.svg
-          │   │   ├── abstract-class-kotlin.svg
           │   │   ├── enum-kotlin.svg
-          │   │   ├── object.svg
+          │   │   ├── enum.svg
+          │   │   ├── exception-class.svg
+          │   │   ├── field-value.svg
+          │   │   ├── field-variable.svg
+          │   │   ├── function.svg
           │   │   ├── interface-kotlin.svg
-          │   │   └── annotation.svg
-          │   ├── burger.svg
-          │   ├── go-to-top-icon.svg
+          │   │   ├── interface.svg
+          │   │   ├── object.svg
+          │   │   └── typealias-kotlin.svg
+          │   ├── anchor-copy-button.svg
           │   ├── arrow_down.svg
+          │   ├── burger.svg
+          │   ├── copy-icon.svg
           │   ├── copy-successful-icon.svg
-          │   ├── theme-toggle.svg
-          │   └── anchor-copy-button.svg
-          ├── styles/
-          │   ├── font-jb-sans-auto.css
-          │   ├── main.css
-          │   ├── prism.css
-          │   ├── style.css
-          │   └── logo-styles.css
+          │   ├── footer-go-to-link.svg
+          │   ├── go-to-top-icon.svg
+          │   ├── logo-icon.svg
+          │   └── theme-toggle.svg
           ├── it-android-0/
           │   ├── it.android/
-          │   │   ├── index.html
-          │   │   ├── -integration-test-activity/
+          │   │   ├── -android-specific-class/
+          │   │   │   ├── -android-specific-class.html
+          │   │   │   ├── create-view.html
           │   │   │   ├── index.html
+          │   │   │   └── sparse-int-array.html
+          │   │   ├── -integration-test-activity/
           │   │   │   ├── -integration-test-activity.html
+          │   │   │   ├── index.html
           │   │   │   └── on-create.html
-          │   │   └── -android-specific-class/
-          │   │       ├── index.html
-          │   │       ├── create-view.html
-          │   │       ├── -android-specific-class.html
-          │   │       └── sparse-int-array.html
+          │   │   └── index.html
           │   └── package-list
           ├── scripts/
-          │   ├── prism.js
-          │   ├── platform-content-handler.js
-          │   ├── symbol-parameters-wrapper_deferred.js
-          │   ├── navigation-loader.js
-          │   ├── main.js
           │   ├── clipboard.js
+          │   ├── main.js
+          │   ├── navigation-loader.js
+          │   ├── pages.json
+          │   ├── platform-content-handler.js
+          │   ├── prism.js
           │   ├── sourceset_dependencies.js
-          │   └── pages.json
+          │   └── symbol-parameters-wrapper_deferred.js
+          ├── styles/
+          │   ├── font-jb-sans-auto.css
+          │   ├── logo-styles.css
+          │   ├── main.css
+          │   ├── prism.css
+          │   └── style.css
+          ├── index.html
           └── navigation.html
-        """.trimIndent()
+""".trimIndent()
 
         val onCreateHtml =
           dokkatooHtmlDir.resolve("it-android-0/it.android/-integration-test-activity/on-create.html")

--- a/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooAndroidAdapter.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/adapters/DokkatooAndroidAdapter.kt
@@ -1,28 +1,24 @@
 package dev.adamko.dokkatoo.adapters
 
-import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestExtension
-import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.internal.dependency.VariantDependencies
-import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType.CLASSES_JAR
-import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType.PROCESSED_JAR
 import dev.adamko.dokkatoo.DokkatooBasePlugin
 import dev.adamko.dokkatoo.DokkatooExtension
 import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
-import dev.adamko.dokkatoo.internal.collectIncomingFiles
+import dev.adamko.dokkatoo.internal.artifactType
+import java.io.File
 import javax.inject.Inject
-import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.kotlin.dsl.*
 
@@ -46,14 +42,13 @@ abstract class DokkatooAndroidAdapter @Inject constructor(
   protected fun configure(project: Project) {
     val dokkatooExtension = project.extensions.getByType<DokkatooExtension>()
 
-    val androidExt = AndroidExtensionWrapper(project)
-
-    if (androidExt == null) {
-      logger.warn("DokkatooAndroidAdapter could not get Android Extension for project ${project.path}")
-      return
-    }
+    val androidExt = AndroidExtensionWrapper(project) ?: return
 
     dokkatooExtension.dokkatooSourceSets.configureEach {
+
+      classpath.from(
+        androidExt.bootClasspath()
+      )
 
       classpath.from(
         analysisPlatform.map { analysisPlatform ->
@@ -61,7 +56,6 @@ abstract class DokkatooAndroidAdapter @Inject constructor(
             KotlinPlatform.AndroidJVM ->
               AndroidClasspathCollector(
                 androidExt = androidExt,
-                configurations = project.configurations,
                 objects = objects,
               )
 
@@ -74,91 +68,88 @@ abstract class DokkatooAndroidAdapter @Inject constructor(
   }
 
   @DokkatooInternalApi
-  companion object {
-    private val logger = Logging.getLogger(DokkatooAndroidAdapter::class.java)
-  }
+  companion object
 }
 
+
+private val logger = Logging.getLogger(DokkatooAndroidAdapter::class.java)
+
+
+/** Create a [AndroidExtensionWrapper] */
 private fun AndroidExtensionWrapper(
   project: Project
 ): AndroidExtensionWrapper? {
-
-// fetching _all_ configuration names is very brute force and should probably be refined to
-// only fetch those that match a specific DokkaSourceSetSpec
-
-  return runCatching {
-    val androidExt = project.extensions.getByType<BaseExtension>()
-    AndroidExtensionWrapper.forBaseExtension(
-      androidExt = androidExt,
-      providers = project.providers,
-      objects = project.objects
-    )
-  }.recoverCatching {
-    val androidExt = project.extensions.getByType(CommonExtension::class)
-    AndroidExtensionWrapper.forCommonExtension(androidExt)
-  }.getOrNull()
+  val androidExt: BaseExtension = try {
+    project.extensions.getByType()
+  } catch (ex: Exception) {
+    logger.warn("DokkatooAndroidAdapter could not get Android Extension for project ${project.path}")
+    return null
+  }
+  return AndroidExtensionWrapper.forBaseExtension(
+    androidExt = androidExt,
+    providers = project.providers,
+    objects = project.objects
+  )
 }
 
+
 /**
- * Android Gradle Plugin is having a refactor. Try to wrap the Android extension so that Dokkatoo
- * can still access the configuration names without caring about which AGP version is in use.
+ * Wrap the Android extension so that Dokkatoo can still access the configuration names without
+ * caring about which AGP version is in use.
  */
 private interface AndroidExtensionWrapper {
-  fun variantConfigurationNames(): Set<String>
+
+  fun variantsCompileClasspath(): FileCollection
+
+  fun bootClasspath(): Provider<List<File>>
 
   companion object {
 
-    @Suppress("DEPRECATION")
     fun forBaseExtension(
       androidExt: BaseExtension,
       providers: ProviderFactory,
       objects: ObjectFactory,
     ): AndroidExtensionWrapper {
       return object : AndroidExtensionWrapper {
-        /** Fetch all configuration names used by all variants. */
-        override fun variantConfigurationNames(): Set<String> {
-          val collector = objects.domainObjectSet(BaseVariant::class)
 
-          val variants: DomainObjectSet<BaseVariant> =
-            collector.apply {
-              addAllLater(providers.provider {
-                when (androidExt) {
-                  is LibraryExtension -> androidExt.libraryVariants
-                  is AppExtension     -> androidExt.applicationVariants
-                  is TestExtension    -> androidExt.applicationVariants
-                  else                -> emptyList()
+        override fun variantsCompileClasspath(): FileCollection {
+          val androidComponentsCompileClasspath = objects.fileCollection()
+
+          val variants = when (androidExt) {
+            is LibraryExtension -> androidExt.libraryVariants
+            is AppExtension     -> androidExt.applicationVariants
+            is TestExtension    -> androidExt.applicationVariants
+            else                -> {
+              logger.warn("DokkatooAndroidAdapter found unknown Android Extension $androidExt")
+              return objects.fileCollection()
+            }
+          }
+
+          fun Configuration.collect(artifactType: String) {
+            val artifactTypeFiles = incoming
+              .artifactView {
+                attributes {
+                  artifactType(artifactType)
                 }
-              })
-            }
+                lenient(true)
+              }
+              .artifacts
+              .resolvedArtifacts
+              .map { artifacts -> artifacts.map(ResolvedArtifactResult::getFile) }
 
-          return buildSet {
-            variants.forEach {
-              add(it.compileConfiguration.name)
-              add(it.runtimeConfiguration.name)
-              add(it.annotationProcessorConfiguration.name)
-            }
+            androidComponentsCompileClasspath.from(artifactTypeFiles)
           }
+
+          variants.all {
+            compileConfiguration.collect("jar")
+            //runtimeConfiguration.collect("jar")
+          }
+
+          return androidComponentsCompileClasspath
         }
-      }
-    }
 
-    fun forCommonExtension(
-      androidExt: CommonExtension<*, *, *, *>
-    ): AndroidExtensionWrapper {
-      return object : AndroidExtensionWrapper {
-        /** Fetch all configuration names used by all variants. */
-        override fun variantConfigurationNames(): Set<String> {
-          return buildSet {
-            @Suppress("UnstableApiUsage")
-            androidExt.sourceSets.forEach {
-              add(it.apiConfigurationName)
-              add(it.compileOnlyConfigurationName)
-              add(it.implementationConfigurationName)
-              add(it.runtimeOnlyConfigurationName)
-              add(it.wearAppConfigurationName)
-              add(it.annotationProcessorConfigurationName)
-            }
-          }
+        override fun bootClasspath(): Provider<List<File>> {
+          return providers.provider { androidExt.bootClasspath }
         }
       }
     }
@@ -172,42 +163,19 @@ private interface AndroidExtensionWrapper {
  * It's important that this class is separate from [DokkatooAndroidAdapter]. It must be separate
  * because it uses Android Gradle Plugin classes (like [BaseExtension]). Were it not separate, and
  * these classes were present in the function signatures of [DokkatooAndroidAdapter], then when
- * Gradle tries to create a decorated instance of [DokkatooAndroidAdapter] it will if the project
- * does not have the Android Gradle Plugin applied, because the classes will be missing.
+ * Gradle tries to create a decorated instance of [DokkatooAndroidAdapter] it will throw an
+ * exception if the project does not have the Android Gradle Plugin applied, because the AGP
+ * classes will be missing.
  */
 private object AndroidClasspathCollector {
 
   operator fun invoke(
     androidExt: AndroidExtensionWrapper,
-    configurations: ConfigurationContainer,
     objects: ObjectFactory,
   ): FileCollection {
     val compilationClasspath = objects.fileCollection()
 
-    fun collectConfiguration(named: String) {
-      listOf(
-        // need to fetch multiple different types of files, because AGP is weird and doesn't seem
-        // to have a 'just give me normal JVM classes' option
-        ARTIFACT_TYPE_ATTRIBUTE to PROCESSED_JAR.type,
-        ARTIFACT_TYPE_ATTRIBUTE to CLASSES_JAR.type,
-      ).forEach { (attribute, attributeValue) ->
-        configurations.collectIncomingFiles(named, collector = compilationClasspath) {
-          attributes {
-            attribute(attribute, attributeValue)
-          }
-          lenient(true)
-        }
-      }
-    }
-
-    // fetch android.jar
-    collectConfiguration(named = VariantDependencies.CONFIG_NAME_ANDROID_APIS)
-
-    val variantConfigurations = androidExt.variantConfigurationNames()
-
-    for (variantConfig in variantConfigurations) {
-      collectConfiguration(named = variantConfig)
-    }
+    compilationClasspath.from({ androidExt.variantsCompileClasspath() })
 
     return compilationClasspath
   }

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
@@ -7,6 +7,8 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
@@ -184,4 +186,23 @@ internal fun ObjectFactory.dokkaPluginParametersContainer(): DokkaPluginParamete
     (container as ExtensionAware).extensions.add(name, this)
   }
   return container
+}
+
+
+/**
+ * Creates a new attribute of the given name with the given type.
+ *
+ * @see Attribute.of
+ */
+internal inline fun <reified T> Attribute(
+  name: String
+): Attribute<T> =
+  Attribute.of(name, T::class.java)
+
+
+internal val ArtifactTypeAttribute: Attribute<String> = Attribute("artifactType")
+
+
+internal fun AttributeContainer.artifactType(value: String) {
+  attribute(ArtifactTypeAttribute, value)
 }

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/fileTree.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/fileTree.kt
@@ -67,7 +67,10 @@ private fun buildTreeString(
 }
 
 private fun File.listDirectoryEntries(): Sequence<File> =
-  walkTopDown().maxDepth(1).filter { it != this@listDirectoryEntries }
+  walkTopDown()
+    .maxDepth(1)
+    .filter { it != this@listDirectoryEntries }
+    .sortedWith(FileSorter)
 
 
 private fun File.countDirectoryEntries(
@@ -89,5 +92,19 @@ private data class PrefixPair(
     val INTERMEDIATE = PrefixPair("├── ", "│   ")
     /** Prefix pair for the last directory entry */
     val LAST_ENTRY = PrefixPair("└── ", "    ")
+  }
+}
+
+
+/**
+ * Directories before files, otherwise sort by filename.
+ */
+private object FileSorter : Comparator<File> {
+  override fun compare(o1: File, o2: File): Int {
+    return when {
+      o1.isDirectory && o2.isFile -> -1 // directories before files
+      o1.isFile && o2.isDirectory -> +1 // files after directories
+      else                        -> o1.name.compareTo(o2.name)
+    }
   }
 }


### PR DESCRIPTION
- Replace deprecated AGP classes where possible (supports more AGP versions, and avoids Gradle buildscript classpath issues).
- Update Android adapter to fetch compile classpath using variants.
- Try to fix/avoid Gradle's variant confusion by specifying JAR where possible when fetching the compile classpath in KotlinAdapter.

Might help with #122