### PR TITLE
fix worker jvm args

### DIFF
--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -410,7 +410,6 @@ public abstract interface class dev/adamko/dokkatoo/workers/ClassLoaderIsolation
 }
 
 public abstract interface class dev/adamko/dokkatoo/workers/ProcessIsolation : dev/adamko/dokkatoo/workers/WorkerIsolation {
-	public abstract fun getAllJvmArgs ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDefaultCharacterEncoding ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableAssertions ()Lorg/gradle/api/provider/Property;

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -99,7 +99,6 @@ constructor(
                 minHeapSize.convention(workerMinHeapSize.orElse(src.minHeapSize))
                 maxHeapSize.convention(workerMaxHeapSize.orElse(src.maxHeapSize))
                 jvmArgs.convention(workerJvmArgs.orElse(src.jvmArgs))
-                allJvmArgs.convention(src.allJvmArgs)
                 defaultCharacterEncoding.convention(src.defaultCharacterEncoding)
                 systemProperties.convention(src.systemProperties)
               }

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -21,7 +21,6 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.*
-import org.gradle.process.JavaForkOptions
 import org.gradle.workers.WorkerExecutor
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.toPrettyJsonString
@@ -129,7 +128,6 @@ constructor(
             isolation.minHeapSize.orNull?.let(this::setMinHeapSize)
             isolation.jvmArgs.orNull?.let(this::setJvmArgs)
             isolation.systemProperties.orNull?.let(this::systemProperties)
-            isolation.allJvmArgs.orNull?.let(this::setAllJvmArgs)
           }
         }
     }
@@ -197,19 +195,89 @@ constructor(
   }
 
   //region Deprecated Properties
-  /** @see JavaForkOptions.getDebug */
+  /**
+   * Please move worker options:
+   *
+   * ```kotlin
+   * // build.gradle.kts
+   *
+   * dokkatoo {
+   *   dokkaGeneratorIsolation = ProcessIsolation {
+   *     debug = true
+   *   }
+   * }
+   * ```
+   *
+   * Worker options were moved to allow for configuring worker isolation.
+   *
+   * @see dev.adamko.dokkatoo.DokkatooExtension.dokkaGeneratorIsolation
+   * @see dev.adamko.dokkatoo.workers.ProcessIsolation.debug
+   */
   @get:Internal
   @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerDebugEnabled: Property<Boolean>
-  /** @see JavaForkOptions.getMinHeapSize */
+  /**
+   * Please move worker options:
+   *
+   * ```kotlin
+   * // build.gradle.kts
+   *
+   * dokkatoo {
+   *   dokkaGeneratorIsolation = ProcessIsolation {
+   *     minHeapSize = "512m"
+   *   }
+   * }
+   * ```
+   *
+   * Worker options were moved to allow for configuring worker isolation.
+   *
+   * @see dev.adamko.dokkatoo.DokkatooExtension.dokkaGeneratorIsolation
+   * @see dev.adamko.dokkatoo.workers.ProcessIsolation.minHeapSize
+   */
   @get:Internal
   @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerMinHeapSize: Property<String>
-  /** @see JavaForkOptions.getMaxHeapSize */
+  /**
+   * Please move worker options:
+   *
+   * ```kotlin
+   * // build.gradle.kts
+   *
+   * dokkatoo {
+   *   dokkaGeneratorIsolation = ProcessIsolation {
+   *     maxHeapSize = "1g"
+   *   }
+   * }
+   * ```
+   *
+   * Worker options were moved to allow for configuring worker isolation.
+   *
+   * @see dev.adamko.dokkatoo.DokkatooExtension.dokkaGeneratorIsolation
+   * @see dev.adamko.dokkatoo.workers.ProcessIsolation.maxHeapSize
+   */
   @get:Internal
   @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerMaxHeapSize: Property<String>
-  /** @see JavaForkOptions.jvmArgs */
+  /**
+   * Please move worker options:
+   *
+   * ```kotlin
+   * // build.gradle.kts
+   *
+   * dokkatoo {
+   *   dokkaGeneratorIsolation = ProcessIsolation {
+   *     jvmArgs = listOf(
+   *       "-XX:+UseStringDeduplication",
+   *     )
+   *   }
+   * }
+   * ```
+   *
+   * Worker options were moved to allow for configuring worker isolation.
+   *
+   * @see dev.adamko.dokkatoo.DokkatooExtension.dokkaGeneratorIsolation
+   * @see dev.adamko.dokkatoo.workers.ProcessIsolation.jvmArgs
+   */
   @get:Internal
   @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerJvmArgs: ListProperty<String>

--- a/modules/dokkatoo-plugin/src/main/kotlin/workers/WorkerIsolationProperties.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/workers/WorkerIsolationProperties.kt
@@ -68,11 +68,6 @@ interface ProcessIsolation : WorkerIsolation {
   @get:Optional
   val jvmArgs: ListProperty<String>
 
-  /** @see JavaForkOptions.setAllJvmArgs */
-  @get:Input
-  @get:Optional
-  val allJvmArgs: ListProperty<String>
-
   /** @see JavaForkOptions.setDefaultCharacterEncoding */
   @get:Input
   @get:Optional


### PR DESCRIPTION
- remove allJvmArgs: it's too error-prone (because it will wipe out all other options)
- update docs to show how to set options in DokkatooExtension