### PR TITLE
log a warning if `all-modules-page-plugin` is missing

### DIFF
--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/projects/MultiModuleProject.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/projects/MultiModuleProject.kt
@@ -1,0 +1,96 @@
+package dev.adamko.dokkatoo.utils.projects
+
+import dev.adamko.dokkatoo.internal.DokkatooConstants
+import dev.adamko.dokkatoo.utils.*
+import io.kotest.core.test.TestScope
+
+
+fun TestScope.initMultiModuleProject(
+  testName: String,
+  config: GradleProjectTest.() -> Unit = {},
+): GradleProjectTest {
+
+  // get the FQN of the class that contains the test, so even though multiple
+  // tests uses this project it's unlikely that the project dirs clash
+  val baseDirName = testCase.descriptor.ids().first().value
+    .substringAfter("dev.adamko.dokkatoo") // drop the package name
+    .replaceNonAlphaNumeric()
+
+  return gradleKtsProjectTest("$baseDirName/multi-module-hello-goodbye/$testName") {
+
+    settingsGradleKts += """
+      |
+      |include(":subproject-hello")
+      |include(":subproject-goodbye")
+      |
+    """.trimMargin()
+
+    buildGradleKts = """
+      |plugins {
+      |  // Kotlin plugin shouldn't be necessary here, but without it Dokka errors
+      |  // with ClassNotFound KotlinPluginExtension... very weird
+      |  kotlin("jvm") version "1.8.22" apply false
+      |  id("dev.adamko.dokkatoo") version "${DokkatooConstants.DOKKATOO_VERSION}"
+      |}
+      |
+      |dependencies {
+      |  dokkatoo(project(":subproject-hello"))
+      |  dokkatoo(project(":subproject-goodbye"))
+      |}
+      |
+    """.trimMargin()
+
+    dir("subproject-hello") {
+      buildGradleKts = """
+          |plugins {
+          |  kotlin("jvm") version "1.8.22"
+          |  id("dev.adamko.dokkatoo") version "${DokkatooConstants.DOKKATOO_VERSION}"
+          |}
+          |
+        """.trimMargin()
+
+      createKotlinFile(
+        "src/main/kotlin/Hello.kt",
+        """
+          |package com.project.hello
+          |
+          |/** The Hello class */
+          |class Hello {
+          |    /** prints `Hello` to the console */  
+          |    fun sayHello() = println("Hello")
+          |}
+          |
+        """.trimMargin()
+      )
+
+      createKotlinFile("src/main/kotlin/HelloAgain.kt", "")
+    }
+
+    dir("subproject-goodbye") {
+
+      buildGradleKts = """
+          |plugins {
+          |  kotlin("jvm") version "1.8.22"
+          |  id("dev.adamko.dokkatoo") version "${DokkatooConstants.DOKKATOO_VERSION}"
+          |}
+          |
+        """.trimMargin()
+
+      createKotlinFile(
+        "src/main/kotlin/Goodbye.kt",
+        """
+          |package com.project.goodbye
+          |
+          |/** The Goodbye class */
+          |class Goodbye {
+          |    /** prints a goodbye message to the console */  
+          |    fun sayHello() = println("Goodbye!")
+          |}
+          |
+        """.trimMargin()
+      )
+    }
+
+    config()
+  }
+}

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/stringUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/stringUtils.kt
@@ -19,3 +19,12 @@ fun String.sortLines(separator: String = "\n") =
   lines()
     .sorted()
     .joinToString(separator)
+
+
+/** Replace characters that don't match [isLetterOrDigit] with [replacement]. */
+internal fun String.replaceNonAlphaNumeric(
+  replacement: String = "-"
+): String =
+  asIterable().joinToString("") { c ->
+    if (c.isLetterOrDigit()) "$c" else replacement
+  }

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/HtmlAggregationWarningTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/HtmlAggregationWarningTest.kt
@@ -1,0 +1,49 @@
+package dev.adamko.dokkatoo
+
+import dev.adamko.dokkatoo.utils.addArguments
+import dev.adamko.dokkatoo.utils.build
+import dev.adamko.dokkatoo.utils.buildGradleKts
+import dev.adamko.dokkatoo.utils.projects.initMultiModuleProject
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+
+class HtmlAggregationWarningTest : FunSpec({
+  context("when all-modules-page-plugin is missing") {
+    val project = initMultiModuleProject("no-all-pages-plugin")
+
+    project.buildGradleKts += """
+      |
+      |// hack, to remove all-modules-page-plugin for testing purposes
+      |afterEvaluate {
+      |  configurations.getByName("dokkatooPluginHtml").dependencies.removeIf {
+      |    it.group == "org.jetbrains.dokka" && it.name == "all-modules-page-plugin"
+      |  }
+      |}
+      |
+    """.trimMargin()
+
+
+    project.runner
+      .addArguments(
+        "clean",
+        ":dokkatooGenerate",
+        "--stacktrace",
+      )
+      .forwardOutput()
+      .build {
+        test("expect warning message is logged") {
+          output shouldContain /* language=text */ """
+              |[:dokkatooGeneratePublicationHtml] org.jetbrains.dokka:all-modules-page-plugin is missing
+              |
+              |Publication 'test' in has 2 modules, but plugins classpath does not contain 
+              |org.jetbrains.dokka:all-modules-page-plugin, which is required for aggregating HTML modules.
+              |
+              |all-modules-page-plugin should be added automatically.
+              |
+              | - verify that the dependency has not been excluded
+              | - raise an issue https://github.com/adamko-dev/dokkatoo/issues
+            """.trimMargin()
+        }
+      }
+  }
+})


### PR DESCRIPTION
- add check in `doFirst {}`
- re-organise DokkatooHtmlPlugin to be a little more modular, with functions for specific configuration tasks
- move the dynamic multimodule project to test-fixtures, so it can be re-used more easily
- move the dynamic multimodule project into a different dir based on the test suite name

Resolves #157 