### PR TITLE
Updated automatic all-modules-page-plugin management

### DIFF
--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/AndroidProjectIntegrationTest.kt
@@ -63,6 +63,11 @@ class AndroidProjectIntegrationTest : FunSpec({
                 )
               }
           }
+
+          test("expect configurations are not resolved during configuration time") {
+            output shouldNotContain Regex("""Configuration '.*' was resolved during configuration time""")
+            output shouldNotContain "https://github.com/gradle/gradle/issues/2298"
+          }
         }
     }
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -325,10 +325,12 @@ constructor(
     const val TASK_GROUP = "dokkatoo"
 
     /** The names of [Gradle tasks][org.gradle.api.Task] created by Dokkatoo */
-    val taskNames = TaskNames(null)
+    val taskNames = TaskNames("")
 
     /** The names of [Configuration]s created by Dokkatoo */
-    val dependencyContainerNames = DependencyContainerNames(null)
+    @Deprecated("no longer used")
+    @Suppress("unused")
+    val dependencyContainerNames = DependencyContainerNames("null")
 
     /** Name of the [Configuration] used to declare dependencies on other subprojects. */
     const val DOKKATOO_CONFIGURATION_NAME = "dokkatoo"

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
@@ -53,7 +53,7 @@ constructor(
    * This is primarily used by Kotlin Multiplatform projects, which can have multiple source sets
    * per subproject.
    *
-   * Defaults to [the path of the subproject][org.gradle.api.Project.getPath].
+   * Defaults to [the Gradle path of the subproject][org.gradle.api.Project.getPath].
    */
   abstract val sourceSetScopeDefault: Property<String>
 

--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/DependencyContainerNames.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/DependencyContainerNames.kt
@@ -14,7 +14,7 @@ import org.gradle.api.artifacts.Configuration
  * - [DokkaConfiguration][org.jetbrains.dokka.DokkaConfiguration] - parameters for executing the Dokka Generator
  */
 @DokkatooInternalApi
-class DependencyContainerNames(override val formatName: String?) : HasFormatName() {
+class DependencyContainerNames(override val formatName: String) : HasFormatName() {
 
   val dokkatoo = DOKKATOO_CONFIGURATION_NAME.appendFormat()
   val dokkatooResolver = "${dokkatoo}Resolver"
@@ -24,7 +24,7 @@ class DependencyContainerNames(override val formatName: String?) : HasFormatName
    *
    * Includes transitive dependencies, so this can be passed to the Dokka Generator Worker classpath.
    *
-   * Will be used in user's build scripts to declare additional Dokka Plugins.
+   * Will be used in user's build scripts to declare additional format-specific Dokka Plugins.
    */
   val pluginsClasspath = "dokkatooPlugin".appendFormat()
 
@@ -51,4 +51,10 @@ class DependencyContainerNames(override val formatName: String?) : HasFormatName
 
   /** Resolver for [generatorClasspath] - internal Dokkatoo usage only. */
   val generatorClasspathResolver = "${dokkatoo}GeneratorClasspathResolver"
+
+  val publicationPluginClasspath = "${dokkatoo}PublicationPluginClasspath"
+  val publicationPluginClasspathApiOnly = "${publicationPluginClasspath}ApiOnly"
+  val publicationPluginClasspathResolver = "${publicationPluginClasspath}Resolver"
+  val publicationPluginClasspathApiOnlyConsumable =
+    "${publicationPluginClasspathApiOnly}Consumable"
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/attributeValues.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/attributeValues.kt
@@ -6,7 +6,6 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.Usage
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.*
 
 
@@ -17,6 +16,8 @@ class BaseAttributes(
 ) {
   val dokkatooUsage: Usage = objects.named("dev.adamko.dokkatoo")
   val dokkaPlugins: DokkatooAttribute.Classpath = objects.named("dokka-plugins")
+  val dokkaPublicationPlugins: DokkatooAttribute.Classpath =
+    objects.named("dokka-publication-plugins")
   val dokkaGenerator: DokkatooAttribute.Classpath = objects.named("dokka-generator")
 }
 
@@ -28,5 +29,7 @@ class FormatAttributes(
   objects: ObjectFactory,
 ) {
   val format: DokkatooAttribute.Format = objects.named(formatName)
-  val moduleOutputDirectories: DokkatooAttribute.ModuleComponent = objects.named("ModuleOutputDirectories")
+
+  val moduleOutputDirectories: DokkatooAttribute.ModuleComponent =
+    objects.named("ModuleOutputDirectories")
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatTasks.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatTasks.kt
@@ -54,7 +54,7 @@ class DokkatooFormatTasks(
     project.tasks.register<DokkatooGeneratePublicationTask>(
       taskNames.generatePublication,
       publication.pluginsConfiguration,
-    ).configuring task@{
+    ).configuring {
       description = "Executes the Dokka Generator, generating the $formatName publication"
 
       outputDirectory.convention(dokkatooExtension.dokkatooPublicationDirectory.dir(formatName))
@@ -66,7 +66,7 @@ class DokkatooFormatTasks(
     project.tasks.register<DokkatooGenerateModuleTask>(
       taskNames.generateModule,
       publication.pluginsConfiguration,
-    ).configuring task@{
+    ).configuring {
       description = "Executes the Dokka Generator, generating a $formatName module"
 
       outputDirectory.convention(dokkatooExtension.dokkatooModuleDirectory.dir(formatName))
@@ -79,7 +79,7 @@ class DokkatooFormatTasks(
   val prepareModuleDescriptor: TaskProvider<dev.adamko.dokkatoo.tasks.DokkatooPrepareModuleDescriptorTask> =
     project.tasks.register<dev.adamko.dokkatoo.tasks.DokkatooPrepareModuleDescriptorTask>(
       taskNames.prepareModuleDescriptor
-    ) task@{
+    ) {
       description = "[Deprecated ⚠️] Prepares the Dokka Module Descriptor for $formatName"
     }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/HasFormatName.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/HasFormatName.kt
@@ -2,12 +2,9 @@ package dev.adamko.dokkatoo.internal
 
 @DokkatooInternalApi
 abstract class HasFormatName {
-  abstract val formatName: String?
+  abstract val formatName: String
 
   /** Appends [formatName] to the end of the string, camelcase style, if [formatName] is not null */
   protected fun String.appendFormat(): String =
-    when (val name = formatName) {
-      null -> this
-      else -> this + name.uppercaseFirstChar()
-    }
+        this + formatName.uppercaseFirstChar()
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateModuleTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateModuleTask.kt
@@ -6,6 +6,7 @@ import dev.adamko.dokkatoo.internal.DokkaPluginParametersContainer
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import java.io.File
 import javax.inject.Inject
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -28,6 +29,7 @@ abstract class DokkatooGenerateModuleTask
 constructor(
   objects: ObjectFactory,
   workers: WorkerExecutor,
+  archives: ArchiveOperations,
   private val fs: FileSystemOperations,
   /**
    * Configurations for Dokka Generator Plugins. Must be provided from
@@ -38,6 +40,7 @@ constructor(
   objects = objects,
   workers = workers,
   pluginsConfiguration = pluginsConfiguration,
+  archives = archives,
 ) {
 
   @get:Input

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGeneratePublicationTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGeneratePublicationTask.kt
@@ -3,11 +3,10 @@ package dev.adamko.dokkatoo.tasks
 import dev.adamko.dokkatoo.internal.DokkaPluginParametersContainer
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import javax.inject.Inject
-import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkerExecutor
 
@@ -25,6 +24,7 @@ abstract class DokkatooGeneratePublicationTask
 constructor(
   objects: ObjectFactory,
   workers: WorkerExecutor,
+  archives: ArchiveOperations,
 
   private val fs: FileSystemOperations,
   /**
@@ -36,6 +36,7 @@ constructor(
   objects = objects,
   workers = workers,
   pluginsConfiguration = pluginsConfiguration,
+  archives = archives,
 ) {
 
   @TaskAction

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/DokkatooGenerateTask.kt
@@ -12,6 +12,7 @@ import dev.adamko.dokkatoo.workers.WorkerIsolation
 import java.io.File
 import javax.inject.Inject
 import kotlinx.serialization.json.JsonElement
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -35,6 +36,7 @@ abstract class DokkatooGenerateTask
 @Inject
 constructor(
   objects: ObjectFactory,
+  archives: ArchiveOperations,
   private val workers: WorkerExecutor,
 
   /**
@@ -43,6 +45,8 @@ constructor(
    */
   pluginsConfiguration: DokkaPluginParametersContainer,
 ) : DokkatooTask() {
+
+  private val dokkaParametersBuilder = DokkaParametersBuilder(archives)
 
   /**
    * Directory containing the generation result. The content and structure depends on whether
@@ -95,12 +99,6 @@ constructor(
   enum class GeneratorMode {
     Module,
     Publication,
-  }
-
-  @Deprecated("Removed - Module and Publication generation has been moved to specific subtasks")
-  enum class GenerationType {
-    MODULE,
-    PUBLICATION,
   }
 
   @DokkatooInternalApi
@@ -176,7 +174,7 @@ constructor(
     val moduleOutputDirectories = generator.moduleOutputDirectories.toList()
     logger.info("[$path] got ${moduleOutputDirectories.size} moduleOutputDirectories: $moduleOutputDirectories")
 
-    return DokkaParametersBuilder.build(
+    return dokkaParametersBuilder.build(
       spec = generator,
       delayTemplateSubstitution = delayTemplateSubstitution,
       outputDirectory = outputDirectory,
@@ -208,6 +206,7 @@ constructor(
   @get:Internal
   @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerDebugEnabled: Property<Boolean>
+
   /**
    * Please move worker options:
    *
@@ -229,6 +228,7 @@ constructor(
   @get:Internal
   @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerMinHeapSize: Property<String>
+
   /**
    * Please move worker options:
    *
@@ -250,6 +250,7 @@ constructor(
   @get:Internal
   @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerMaxHeapSize: Property<String>
+
   /**
    * Please move worker options:
    *
@@ -274,14 +275,22 @@ constructor(
   @Deprecated("Please move worker options to `DokkatooExtension.dokkaGeneratorIsolation`. Worker options were moved to allow for configuring worker isolation")
   abstract val workerJvmArgs: ListProperty<String>
 
+  @Deprecated("Removed - Module and Publication generation have been moved to specific subtasks")
+  @Suppress("unused")
+  enum class GenerationType {
+    MODULE,
+    PUBLICATION,
+  }
 
   /**
-   * Generating a Dokka Module? Set this to [GenerationType.MODULE].
+   * Deprecated - instead use specific subtasks for Module/Publication generation.
    *
-   * Generating a Dokka Publication? [GenerationType.PUBLICATION].
+   * @see DokkatooGenerateModuleTask
+   * @see DokkatooGeneratePublicationTask
    */
   @get:Internal
   @Deprecated("Created specific Module/Publication subclasses")
+  @Suppress("DEPRECATION", "unused")
   abstract val generationType: Property<GenerationType>
   //endregion
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/LogHtmlPublicationLinkTask.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/LogHtmlPublicationLinkTask.kt
@@ -87,8 +87,9 @@ constructor(
 
     val logHtmlPublicationLinkTaskEnabled = providers
       .gradleProperty(ENABLE_TASK_PROPERTY_NAME)
-      .orElse("true")
       .map(String::toBoolean)
+      .orElse(true)
+
     super.onlyIf("task is enabled via property") {
       logHtmlPublicationLinkTaskEnabled.get()
     }

--- a/modules/dokkatoo-plugin/src/main/kotlin/tasks/TaskNames.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/tasks/TaskNames.kt
@@ -4,7 +4,7 @@ import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import dev.adamko.dokkatoo.internal.HasFormatName
 
 @DokkatooInternalApi
-class TaskNames(override val formatName: String?) : HasFormatName() {
+class TaskNames(override val formatName: String) : HasFormatName() {
   val generate = "dokkatooGenerate".appendFormat()
   val generatePublication = "dokkatooGeneratePublication".appendFormat()
   val generateModule = "dokkatooGenerateModule".appendFormat()

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/projects/MultiModuleProject.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/projects/MultiModuleProject.kt
@@ -13,7 +13,7 @@ fun TestScope.initMultiModuleProject(
   // get the FQN of the class that contains the test, so even though multiple
   // tests uses this project it's unlikely that the project dirs clash
   val baseDirName = testCase.descriptor.ids().first().value
-    .substringAfter("dev.adamko.dokkatoo") // drop the package name
+    .substringAfter("dev.adamko.dokkatoo.") // drop the package name
     .replaceNonAlphaNumeric()
 
   return gradleKtsProjectTest("$baseDirName/multi-module-hello-goodbye/$testName") {

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooPluginFunctionalTest.kt
@@ -64,6 +64,7 @@ class DokkatooPluginFunctionalTest : FunSpec({
           expectedFormats.flatMap {
             listOf(
               "dokkatoo${it}ModuleOutputDirectoriesConsumable",
+              "dokkatoo${it}PublicationPluginClasspathApiOnlyConsumable",
             )
           }
         )
@@ -111,8 +112,9 @@ class DokkatooPluginFunctionalTest : FunSpec({
             buildSet {
               addAll(expectedFormats.map { "dokkatoo${it}Resolver" })
               addAll(expectedFormats.map { "dokkatoo${it}GeneratorClasspathResolver" })
-              addAll(expectedFormats.map { "dokkatoo${it}PluginsClasspathIntransitiveResolver" })
               addAll(expectedFormats.map { "dokkatoo${it}ModuleOutputDirectoriesResolver" })
+              addAll(expectedFormats.map { "dokkatoo${it}PluginsClasspathIntransitiveResolver" })
+              addAll(expectedFormats.map { "dokkatoo${it}PublicationPluginClasspathResolver" })
             }
           )
 

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -229,6 +229,7 @@ class MultiModuleFunctionalTest : FunSpec({
             ":dokkatooGenerate",
             "--stacktrace",
             "--build-cache",
+            "-D" + "org.gradle.caching.debug=true"
           )
           .forwardOutput()
           .build {
@@ -623,7 +624,9 @@ class MultiModuleFunctionalTest : FunSpec({
               .walk()
               .filter { it.isFile && it.extension == "html" }
 
-            htmlFiles.shouldNotBeEmpty()
+            withClue("html files should be generated") {
+              htmlFiles.shouldNotBeEmpty()
+            }
 
             htmlFiles.forEach { htmlFile ->
               val relativePath = htmlFile.relativeTo(project.projectDir.toFile())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-
   repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
 
   repositories {


### PR DESCRIPTION
- improved 'missing all-modules-page-plugin' warning message
- added option to disable 'missing all-modules-page-plugin' warning
- all-modules-page-plugin now provided as a transitive dependency
- exclude non-plugin dependencies from generator Dokka Plugins classpath (by checking for Dokka Plugin marker file)
- updated some Configurations to be registered lazily
- tidy up default Dokka dependencies (remove non-plugins from plugins classpath)