### PR TITLE
remove `Gradle.rootGradle` util

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,8 +1,3 @@
-@file:OptIn(ExperimentalEncodingApi::class)
-
-import kotlin.io.encoding.Base64.Default.decode
-import kotlin.io.encoding.ExperimentalEncodingApi
-
 rootProject.name = "buildSrc"
 
 pluginManagement {

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/maven-publish-test.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/maven-publish-test.gradle.kts
@@ -10,11 +10,10 @@ plugins {
   base
 }
 
-val Gradle.rootGradle: Gradle get() = generateSequence(gradle) { it.parent }.last()
 
 val mavenPublishTestExtension = extensions.create<MavenPublishTestSettings>(
   "mavenPublishTest",
-  gradle.rootGradle.rootProject.layout.buildDirectory.dir("test-maven-repo"),
+  gradle.rootProject.layout.buildDirectory.dir("test-maven-repo"),
 )
 
 


### PR DESCRIPTION
remove `Gradle.rootGradle` - it errors when Dokkatoo is used as an included build.

Also remove unused imports from buildSrc/settings.gradle.kts