### PR TITLE
prevent Kotlin DSL accessor generation for internal BaseDependencyManager

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -51,8 +51,6 @@ constructor(
 
     val dokkatooExtension = createExtension(target)
 
-    createBaseDependencyManager(target = target)
-
     configureDependencyAttributes(target)
 
     configureDokkaPublicationsDefaults(dokkatooExtension)
@@ -61,7 +59,16 @@ constructor(
   }
 
   private fun createExtension(project: Project): DokkatooExtension {
-    val dokkatooExtension = project.extensions.create<DokkatooExtension>(EXTENSION_NAME).apply {
+
+    val baseDependencyManager = BaseDependencyManager(
+      project = project,
+      objects = objects,
+    )
+
+    val dokkatooExtension = project.extensions.create<DokkatooExtension>(
+      EXTENSION_NAME,
+      baseDependencyManager,
+    ).apply {
       moduleName.convention(providers.provider { project.name })
       moduleVersion.convention(providers.provider { project.version.toString() })
       modulePath.convention(project.pathAsFilePath())
@@ -110,20 +117,6 @@ constructor(
     )
 
     return dokkatooExtension
-  }
-
-
-  private fun createBaseDependencyManager(
-    target: Project,
-  ) {
-    val baseDependencyManager = BaseDependencyManager(
-      project = target,
-      objects = objects,
-    )
-    target.extensions.adding(
-      "dokkatooBaseDependencyManager$INTERNAL_MARKER",
-      baseDependencyManager
-    )
   }
 
 
@@ -334,9 +327,6 @@ constructor(
 
     /** Name of the [Configuration] used to declare dependencies on other subprojects. */
     const val DOKKATOO_CONFIGURATION_NAME = "dokkatoo"
-
-    /** disable Kotlin DSL accessors by adding `~` */
-    internal const val INTERNAL_MARKER = "~internal"
 
     internal val jsonMapper = Json {
       prettyPrint = true

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooExtension.kt
@@ -1,5 +1,6 @@
 package dev.adamko.dokkatoo
 
+import dev.adamko.dokkatoo.dependencies.BaseDependencyManager
 import dev.adamko.dokkatoo.dokka.DokkaPublication
 import dev.adamko.dokkatoo.dokka.parameters.DokkaSourceSetSpec
 import dev.adamko.dokkatoo.internal.*
@@ -24,6 +25,7 @@ abstract class DokkatooExtension
 @DokkatooInternalApi
 constructor(
   private val objects: ObjectFactory,
+  internal val baseDependencyManager: BaseDependencyManager,
 ) : ExtensionAware, Serializable {
 
   /** Directory into which [DokkaPublication]s will be produced */

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -5,7 +5,6 @@ import dev.adamko.dokkatoo.DokkatooExtension
 import dev.adamko.dokkatoo.adapters.DokkatooAndroidAdapter
 import dev.adamko.dokkatoo.adapters.DokkatooJavaAdapter
 import dev.adamko.dokkatoo.adapters.DokkatooKotlinAdapter
-import dev.adamko.dokkatoo.dependencies.BaseDependencyManager
 import dev.adamko.dokkatoo.dependencies.DependencyContainerNames
 import dev.adamko.dokkatoo.dependencies.DokkatooAttribute.Companion.DokkatooClasspathAttribute
 import dev.adamko.dokkatoo.dependencies.DokkatooAttribute.Companion.DokkatooFormatAttribute
@@ -70,11 +69,9 @@ abstract class DokkatooFormatPlugin(
 
       val publication = dokkatooExtension.dokkatooPublications.create(formatName)
 
-      val baseDependencyManager = target.extensions.getByType<BaseDependencyManager>()
-
       val formatDependencies = FormatDependenciesManager(
         project = target,
-        baseDependencyManager = baseDependencyManager,
+        baseDependencyManager = dokkatooExtension.baseDependencyManager,
         formatName = formatName,
         objects = objects,
       )

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/AttributeHackTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/AttributeHackTest.kt
@@ -1,6 +1,6 @@
 package dev.adamko.dokkatoo
 
-import dev.adamko.dokkatoo.internal.DokkatooConstants
+import dev.adamko.dokkatoo.internal.DokkatooConstants.DOKKATOO_VERSION
 import dev.adamko.dokkatoo.utils.*
 import io.kotest.core.spec.style.FunSpec
 
@@ -46,12 +46,13 @@ private fun initProject(
       buildGradleKts = """
           |plugins {
           |  kotlin("multiplatform") version embeddedKotlinVersion
-          |  id("dev.adamko.dokkatoo-html") version "${DokkatooConstants.DOKKATOO_VERSION}"
+          |  id("dev.adamko.dokkatoo-html") version "$DOKKATOO_VERSION"
           |}
           |
           |kotlin {
           |  jvm()
           |}
+          |
         """.trimMargin()
     }
 

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinDslAccessorsTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinDslAccessorsTest.kt
@@ -1,0 +1,84 @@
+package dev.adamko.dokkatoo
+
+import dev.adamko.dokkatoo.internal.DokkatooConstants.DOKKATOO_VERSION
+import dev.adamko.dokkatoo.utils.*
+import io.kotest.core.spec.style.FunSpec
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+
+class KotlinDslAccessorsTest : FunSpec({
+
+  val project = initProject()
+
+  test("Dokkatoo DSL accessors do not trigger compilation warnings") {
+
+    project
+      .runner
+      .forwardOutput()
+      .addArguments(
+        ":clean",
+        ":compileKotlin",
+        "--project-dir", "buildSrc",
+        "--rerun-tasks",
+        "--no-build-cache",
+        "--no-configuration-cache",
+      )
+      .build {
+        shouldHaveTaskWithOutcome(":compileKotlin", SUCCESS)
+      }
+  }
+})
+
+
+private fun initProject(
+  config: GradleProjectTest.() -> Unit = {},
+): GradleProjectTest {
+  return gradleKtsProjectTest("kotlin-dsl-accessors-test") {
+
+    buildGradleKts = """
+      |plugins {
+      |  base
+      |  id("dokkatoo-convention")
+      |}
+      |
+    """.trimMargin()
+
+    dir("buildSrc") {
+      buildGradleKts = """
+          |plugins {
+          |  `kotlin-dsl`
+          |}
+          |
+          |dependencies {
+          |  implementation("dev.adamko.dokkatoo:dokkatoo-plugin:$DOKKATOO_VERSION")
+          |}
+          |
+          |kotlin {
+          |  compilerOptions {
+          |    allWarningsAsErrors.set(true)
+          |  }
+          |}
+          |
+        """.trimMargin()
+
+      settingsGradleKts = """
+          |rootProject.name = "buildSrc"
+          |
+          |${settingsRepositories()}
+          |
+        """.trimMargin()
+
+      createKtsFile(
+        "src/main/kotlin/dokkatoo-convention.gradle.kts",
+        """
+          |plugins {
+          |  id("dev.adamko.dokkatoo")
+          |}
+          |
+        """.trimMargin()
+      )
+    }
+
+    config()
+  }
+}


### PR DESCRIPTION
prevent Kotlin DSL accessor generation for internal BaseDependencyManager

- remove BaseDependencyManager as a Project extension, so Gradle doesn't generate an accessor for it, which triggers an opt-in warning
- tidy up Project test DSL

fix #176 