### PR TITLE
GitHub Actions: allow Gradle Build Cache to be written on release branches, and tags

### DIFF
--- a/.github/workflows/run_gradle_task.yml
+++ b/.github/workflows/run_gradle_task.yml
@@ -82,6 +82,8 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
           arguments: ${{ inputs.gradle-task }}
+          # write build cache on 'main' and 'release' branches, or tags (default is 'main' only)
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release') && !startsWith(github.ref, 'refs/tags/') }}
         env:
           MAVEN_SONATYPE_USERNAME: ${{ vars.MAVEN_SONATYPE_USERNAME }}
           MAVEN_SONATYPE_PASSWORD: ${{ secrets.MAVEN_SONATYPE_PASSWORD }}

--- a/.github/workflows/run_publish_site.yml
+++ b/.github/workflows/run_publish_site.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         with:
           gradle-home-cache-cleanup: true
+          # write build cache on 'main' and 'release' branches, or tags (default is 'main' only)
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release') && !startsWith(github.ref, 'refs/tags/') }}
           arguments: |
             :modules:docs:dokkatooGenerate
 


### PR DESCRIPTION
Allow Gradle Build Cache to be written on release branches, and tags. This will hopefully improve release performance.