### PR TITLE
Add `dokkatooPlugin` parent Configuration

### DIFF
--- a/examples/kotlin-as-java-example/dokkatoo/build.gradle.kts
+++ b/examples/kotlin-as-java-example/dokkatoo/build.gradle.kts
@@ -8,9 +8,5 @@ dependencies {
 
   // Will apply the plugin only to the `:dokkaHtml` task
   // (Dokkatoo will automatically add the version)
-  dokkatooPluginHtml("org.jetbrains.dokka:kotlin-as-java-plugin")
-
-  // Will apply the plugin only to the `:dokkaGfm` task
-  // (Dokkatoo will automatically add the version)
-  dokkatooPluginGfm("org.jetbrains.dokka:kotlin-as-java-plugin")
+  dokkatooPlugin("org.jetbrains.dokka:kotlin-as-java-plugin")
 }

--- a/examples/multimodule-example/dokkatoo/parentProject/build.gradle.kts
+++ b/examples/multimodule-example/dokkatoo/parentProject/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
 dependencies {
   dokkatoo(project(":parentProject:childProjectA"))
   dokkatoo(project(":parentProject:childProjectB"))
-
-  dokkatooPluginHtml("org.jetbrains.dokka:templating-plugin")
 }
 
 dokkatoo {

--- a/modules/docs/site/docs/configuring/dokka-engine-plugins.md
+++ b/modules/docs/site/docs/configuring/dokka-engine-plugins.md
@@ -6,10 +6,9 @@ In fact, all formats created by Dokka Generator are Dokka Engine Plugins.
 
 ## Adding Dokka Engine Plugins
 
-To add a Dokka Engine Plugin to Dokkatoo, add it as a dependency in the format you want to modify.
+To add a Dokka Engine Plugin to Dokkatoo, add it as a dependency to all formats, or in the format you want to modify.
 
-The
-dependency  [Gradle dependency format](https://docs.gradle.org/8.6/userguide/declaring_dependencies.html)
+Any [Gradle dependency format](https://docs.gradle.org/8.6/userguide/declaring_dependencies.html)
 is supported.
 
 ```kotlin title="build.gradle.kts"
@@ -18,26 +17,19 @@ plugins {
 }
 
 dependencies {
-  // use Maven coordinates,
-  dokkatooPluginHtml("com.glureau:html-mermaid-dokka-plugin:0.6.0")
+  // Add a plugin when generating all formats, using Maven coordinates,
+  dokkatooPlugin("com.glureau:html-mermaid-dokka-plugin:0.6.0")
 
-  // or a Version Catalog plugin
-  dokkatooPluginJekyll(libs.dokkaPlugins.somePlugin)
+  // Add a Version Catalog entry to a specific format
+  dokkatooPluginHtml(libs.dokkaPlugins.somePlugin)
 
-  // or a local file
+  // or a local JAR file
   dokkatooPluginJavadoc(files("dokka-plugins/my-custom-plugin.jar"))
 
-  // or a subproject
+  // or another subproject
   dokkatooPluginGfm(project(":local-dokka-plugin"))
 }
 ```
-
-:::tip
-
-For a shorter way of adding a Dokka Engine Plugin to _all_ Dokkatoo
-formats, [watch this issue](https://github.com/adamko-dev/dokkatoo/issues/186).
-
-:::
 
 ## Configuring Dokka Engine Plugins
 
@@ -79,7 +71,7 @@ plugins {
 }
 
 dependencies {
-  dokkatooPluginHtml("foo.example:custom-dokka-plugin:1.2.3")
+  dokkatooPlugin("foo.example:custom-dokka-plugin:1.2.3")
 }
 
 dokkatoo {

--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -1,6 +1,7 @@
 public abstract class dev/adamko/dokkatoo/DokkatooBasePlugin : org/gradle/api/Plugin {
 	public static final field Companion Ldev/adamko/dokkatoo/DokkatooBasePlugin$Companion;
 	public static final field DOKKATOO_CONFIGURATION_NAME Ljava/lang/String;
+	public static final field DOKKA_GENERATOR_PLUGINS_CONFIGURATION_NAME Ljava/lang/String;
 	public static final field EXTENSION_NAME Ljava/lang/String;
 	public static final field TASK_GROUP Ljava/lang/String;
 	public synthetic fun apply (Ljava/lang/Object;)V

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -328,6 +328,9 @@ constructor(
     /** Name of the [Configuration] used to declare dependencies on other subprojects. */
     const val DOKKATOO_CONFIGURATION_NAME = "dokkatoo"
 
+    /** Name of the [Configuration] used to declare dependencies on Dokka Generator plugins. */
+    const val DOKKA_GENERATOR_PLUGINS_CONFIGURATION_NAME = "dokkatooPlugin"
+
     internal val jsonMapper = Json {
       prettyPrint = true
       @OptIn(ExperimentalSerializationApi::class)

--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/BaseDependencyManager.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/BaseDependencyManager.kt
@@ -1,6 +1,7 @@
 package dev.adamko.dokkatoo.dependencies
 
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.DOKKATOO_CONFIGURATION_NAME
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.DOKKA_GENERATOR_PLUGINS_CONFIGURATION_NAME
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import dev.adamko.dokkatoo.internal.declarable
 import org.gradle.api.Project
@@ -21,7 +22,13 @@ class BaseDependencyManager(
 
   val declaredDependencies: Configuration =
     project.configurations.create(DOKKATOO_CONFIGURATION_NAME) {
-      description = "Fetch all Dokkatoo files from all configurations in other subprojects"
+      description = "Fetch all Dokkatoo files from all configurations in other subprojects."
+      declarable()
+    }
+
+  val dokkaGeneratorPlugins: Configuration =
+    project.configurations.create(DOKKA_GENERATOR_PLUGINS_CONFIGURATION_NAME) {
+      description = "Dokka Plugins classpath, that will be used by all formats."
       declarable()
     }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/DependencyContainerNames.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/DependencyContainerNames.kt
@@ -2,6 +2,7 @@ package dev.adamko.dokkatoo.dependencies
 
 import dev.adamko.dokkatoo.DokkatooBasePlugin
 import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.DOKKATOO_CONFIGURATION_NAME
+import dev.adamko.dokkatoo.DokkatooBasePlugin.Companion.DOKKA_GENERATOR_PLUGINS_CONFIGURATION_NAME
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
 import dev.adamko.dokkatoo.internal.HasFormatName
 import org.gradle.api.artifacts.Configuration
@@ -26,7 +27,7 @@ class DependencyContainerNames(override val formatName: String) : HasFormatName(
    *
    * Will be used in user's build scripts to declare additional format-specific Dokka Plugins.
    */
-  val pluginsClasspath = "dokkatooPlugin".appendFormat()
+  val pluginsClasspath = DOKKA_GENERATOR_PLUGINS_CONFIGURATION_NAME.appendFormat()
 
   /**
    * ### Dokka Plugins (excluding transitive dependencies)

--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/FormatDependenciesManager.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/FormatDependenciesManager.kt
@@ -77,6 +77,7 @@ class FormatDependenciesManager(
     project.configurations.register(configurationNames.pluginsClasspath) {
       description = "Dokka Plugins classpath for $formatName."
       declarable()
+      extendsFrom(baseDependencyManager.dokkaGeneratorPlugins)
     }
 
   /**

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinMultiplatformFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinMultiplatformFunctionalTest.kt
@@ -168,11 +168,6 @@ private fun initKotlinMultiplatformProject(
       |  }
       |}
       |
-      |dependencies {
-      |  // must manually add this dependency for aggregation to work
-      |  //dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin:1.8.10")
-      |}
-      |
       |dokkatoo {
       |  dokkatooSourceSets.configureEach {
       |    externalDocumentationLinks {


### PR DESCRIPTION

Add `dokkatooPlugin` parent Configuration, for all Dokka Generator Plugins.

This makes it easier to add a Dokka Generator Plugin.

Resolves #186