### PR TITLE
Fix Dokkatoo configurations default visibility

### DIFF
--- a/examples/java-example/dokkatoo/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
+++ b/examples/java-example/dokkatoo/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
@@ -20,5 +20,5 @@ dependencies {
   dokkatooPluginHtml("org.jetbrains.dokka:kotlin-as-java-plugin")
   dokkatooPluginJavadoc("org.jetbrains.dokka:kotlin-as-java-plugin")
   dokkatooPluginJekyll("org.jetbrains.dokka:kotlin-as-java-plugin")
-  dokkatooPluginMarkdown("org.jetbrains.dokka:kotlin-as-java-plugin")
+  dokkatooPluginGfm("org.jetbrains.dokka:kotlin-as-java-plugin")
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
@@ -51,7 +51,7 @@ internal fun Configuration.declarable(
  * ```
  */
 internal fun Configuration.consumable(
-  visible: Boolean = true,
+  visible: Boolean = false,
 ) {
   isCanBeResolved = false
   isCanBeConsumed = true

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooBaseTasksLinksTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/DokkatooBaseTasksLinksTest.kt
@@ -1,0 +1,41 @@
+package dev.adamko.dokkatoo
+
+import dev.adamko.dokkatoo.utils.addArguments
+import dev.adamko.dokkatoo.utils.build
+import dev.adamko.dokkatoo.utils.name
+import dev.adamko.dokkatoo.utils.projects.initMultiModuleProject
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.inspectors.shouldForAll
+import io.kotest.inspectors.shouldForOne
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContainIgnoringCase
+
+class DokkatooBaseTasksLinksTest : FunSpec({
+
+  context("Verify that the base lifecycle tasks do not trigger Dokkatoo tasks") {
+    val project = initMultiModuleProject("TaskLinks")
+
+    withData(
+      "assemble",
+      "build",
+      "check",
+      "clean",
+    ) { baseTask ->
+      project.runner
+        .addArguments(
+          baseTask,
+          "--quiet",
+        )
+        .build {
+          tasks.shouldForOne { it.path shouldBe ":${baseTask}" }
+          tasks.shouldForOne { it.path shouldBe ":subproject-goodbye:${baseTask}" }
+          tasks.shouldForOne { it.path shouldBe ":subproject-hello:${baseTask}" }
+
+          tasks.shouldForAll { task ->
+            task.name shouldNotContainIgnoringCase "dokkatoo"
+          }
+        }
+    }
+  }
+})


### PR DESCRIPTION
Don't make Dokkatoo Configurations visible by default, Gradle adds an automatic link to assemble tasks for some weird reason.

Fix https://github.com/adamko-dev/dokkatoo/discussions/203