### PR TITLE
workaround bugged Gradle attributes

### DIFF
--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/DokkatooAttribute.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/DokkatooAttribute.kt
@@ -16,25 +16,34 @@ interface DokkatooAttribute {
 
   /** HTML, Markdown, etc. */
   @DokkatooInternalApi
-  interface Format : Named
+  @JvmInline
+  value class Format(private val named: String) : Named {
+    override fun getName(): String = named
+  }
 
   /** Generated output, or subproject classpath, or included files, etc */
   @DokkatooInternalApi
-  interface ModuleComponent : Named
+  @JvmInline
+  value class ModuleComponent(private val named: String) : Named {
+    override fun getName(): String = named
+  }
 
   /** A classpath, e.g. for Dokka Plugins or the Dokka Generator. */
   @DokkatooInternalApi
-  interface Classpath : Named
+  @JvmInline
+  value class Classpath(private val named: String) : Named {
+    override fun getName(): String = named
+  }
 
   @DokkatooInternalApi
   companion object {
-    val DokkatooFormatAttribute: Attribute<Format> =
+    val DokkatooFormatAttribute: Attribute<String> =
       Attribute("dev.adamko.dokkatoo.format")
 
-    val DokkatooModuleComponentAttribute: Attribute<ModuleComponent> =
+    val DokkatooModuleComponentAttribute: Attribute<String> =
       Attribute("dev.adamko.dokkatoo.module-component")
 
-    val DokkatooClasspathAttribute: Attribute<Classpath> =
+    val DokkatooClasspathAttribute: Attribute<String> =
       Attribute("dev.adamko.dokkatoo.classpath")
   }
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/FormatDependenciesManager.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/FormatDependenciesManager.kt
@@ -48,7 +48,6 @@ class FormatDependenciesManager(
   internal val formatAttributes: FormatAttributes =
     FormatAttributes(
       formatName = formatName,
-      objects = objects,
     )
 
   init {
@@ -94,8 +93,8 @@ class FormatDependenciesManager(
       isTransitive = false
       attributes {
         jvmJar()
-        attribute(DokkatooFormatAttribute, formatAttributes.format)
-        attribute(DokkatooClasspathAttribute, baseAttributes.dokkaPlugins)
+        attribute(DokkatooFormatAttribute, formatAttributes.format.name)
+        attribute(DokkatooClasspathAttribute, baseAttributes.dokkaPlugins.name)
       }
     }
   //endregion
@@ -117,8 +116,8 @@ class FormatDependenciesManager(
       extendsFrom(dokkaPublicationPluginClasspath.get())
       attributes {
         jvmJar()
-        attribute(DokkatooFormatAttribute, formatAttributes.format)
-        attribute(DokkatooClasspathAttribute, baseAttributes.dokkaPublicationPlugins)
+        attribute(DokkatooFormatAttribute, formatAttributes.format.name)
+        attribute(DokkatooClasspathAttribute, baseAttributes.dokkaPublicationPlugins.name)
       }
     }
 
@@ -137,8 +136,8 @@ class FormatDependenciesManager(
       extendsFrom(dokkaPublicationPluginClasspathApiOnly.get())
       attributes {
         jvmJar()
-        attribute(DokkatooFormatAttribute, formatAttributes.format)
-        attribute(DokkatooClasspathAttribute, baseAttributes.dokkaPublicationPlugins)
+        attribute(DokkatooFormatAttribute, formatAttributes.format.name)
+        attribute(DokkatooClasspathAttribute, baseAttributes.dokkaPublicationPlugins.name)
       }
     }
   }
@@ -186,8 +185,8 @@ class FormatDependenciesManager(
 
       attributes {
         jvmJar()
-        attribute(DokkatooFormatAttribute, formatAttributes.format)
-        attribute(DokkatooClasspathAttribute, baseAttributes.dokkaGenerator)
+        attribute(DokkatooFormatAttribute, formatAttributes.format.name)
+        attribute(DokkatooClasspathAttribute, baseAttributes.dokkaGenerator.name)
       }
     }
   //endregion

--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/ModuleComponentDependencies.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/ModuleComponentDependencies.kt
@@ -33,8 +33,8 @@ class ModuleComponentDependencies(
       extendsFrom(declaredDependencies)
       attributes {
         attribute(USAGE_ATTRIBUTE, baseAttributes.dokkatooUsage)
-        attribute(DokkatooFormatAttribute, formatAttributes.format)
-        attribute(DokkatooModuleComponentAttribute, component)
+        attribute(DokkatooFormatAttribute, formatAttributes.format.name)
+        attribute(DokkatooModuleComponentAttribute, component.name)
       }
     }
 
@@ -46,8 +46,8 @@ class ModuleComponentDependencies(
       extendsFrom(declaredDependencies)
       attributes {
         attribute(USAGE_ATTRIBUTE, baseAttributes.dokkatooUsage)
-        attribute(DokkatooFormatAttribute, formatAttributes.format)
-        attribute(DokkatooModuleComponentAttribute, component)
+        attribute(DokkatooFormatAttribute, formatAttributes.format.name)
+        attribute(DokkatooModuleComponentAttribute, component.name)
       }
     }
 
@@ -83,8 +83,8 @@ class ModuleComponentDependencies(
         withVariantReselection()
         attributes {
           attribute(USAGE_ATTRIBUTE, usage)
-          attribute(DokkatooFormatAttribute, formatAttributes.format)
-          attribute(DokkatooModuleComponentAttribute, component)
+          attribute(DokkatooFormatAttribute, formatAttributes.format.name)
+          attribute(DokkatooModuleComponentAttribute, component.name)
         }
         lenient(true)
       }
@@ -98,23 +98,23 @@ class ModuleComponentDependencies(
           .filter { artifact ->
             val variantAttributes = artifact.variant.attributes
             when {
-              artifact.variant.attributes[USAGE_ATTRIBUTE]?.name != baseAttributes.dokkatooUsage.name -> {
-                logger.info("[${incomingName}] ignoring artifact $artifact - USAGE_ATTRIBUTE != ${baseAttributes.dokkatooUsage} | attributes:${variantAttributes.toMap()}")
+              variantAttributes[USAGE_ATTRIBUTE]?.name != baseAttributes.dokkatooUsage.name -> {
+                logger.info("[${incomingName}] ignoring artifact $artifact - USAGE_ATTRIBUTE != ${baseAttributes.dokkatooUsage} | attributes:${variantAttributes.toDebugString()}")
                 false
               }
 
-              variantAttributes[DokkatooFormatAttribute]?.name != formatAttributes.format.name        -> {
-                logger.info("[${incomingName}] ignoring artifact $artifact - DokkatooFormatAttribute != ${formatAttributes.format} | attributes:${variantAttributes.toMap()}")
+              variantAttributes[DokkatooFormatAttribute] != formatAttributes.format.name    -> {
+                logger.info("[${incomingName}] ignoring artifact $artifact - DokkatooFormatAttribute != ${formatAttributes.format} | attributes:${variantAttributes.toDebugString()}")
                 false
               }
 
-              variantAttributes[DokkatooModuleComponentAttribute]?.name != component.name             -> {
-                logger.info("[${incomingName}] ignoring artifact $artifact - DokkatooModuleComponentAttribute != $component | attributes:${variantAttributes.toMap()}")
+              variantAttributes[DokkatooModuleComponentAttribute] != component.name         -> {
+                logger.info("[${incomingName}] ignoring artifact $artifact - DokkatooModuleComponentAttribute != $component | attributes:${variantAttributes.toDebugString()}")
                 false
               }
 
-              else                                                                                    -> {
-                logger.info("[${incomingName}] found valid artifact $artifact | attributes:${variantAttributes.toMap()}")
+              else                                                                          -> {
+                logger.info("[${incomingName}] found valid artifact $artifact | attributes:${variantAttributes.toDebugString()}")
                 true
               }
             }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dependencies/attributeValues.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dependencies/attributeValues.kt
@@ -15,10 +15,15 @@ class BaseAttributes(
   objects: ObjectFactory,
 ) {
   val dokkatooUsage: Usage = objects.named("dev.adamko.dokkatoo")
-  val dokkaPlugins: DokkatooAttribute.Classpath = objects.named("dokka-plugins")
+
+  val dokkaPlugins: DokkatooAttribute.Classpath =
+    DokkatooAttribute.Classpath("dokka-plugins")
+
   val dokkaPublicationPlugins: DokkatooAttribute.Classpath =
-    objects.named("dokka-publication-plugins")
-  val dokkaGenerator: DokkatooAttribute.Classpath = objects.named("dokka-generator")
+    DokkatooAttribute.Classpath("dokka-publication-plugins")
+
+  val dokkaGenerator: DokkatooAttribute.Classpath =
+    DokkatooAttribute.Classpath("dokka-generator")
 }
 
 
@@ -26,10 +31,10 @@ class BaseAttributes(
 @DokkatooInternalApi
 class FormatAttributes(
   formatName: String,
-  objects: ObjectFactory,
 ) {
-  val format: DokkatooAttribute.Format = objects.named(formatName)
+  val format: DokkatooAttribute.Format =
+    DokkatooAttribute.Format(formatName)
 
   val moduleOutputDirectories: DokkatooAttribute.ModuleComponent =
-    objects.named("ModuleOutputDirectories")
+    DokkatooAttribute.ModuleComponent("ModuleOutputDirectories")
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -165,13 +165,13 @@ abstract class DokkatooFormatPlugin(
       dokkatooExtension.versions.jetbrainsDokka.map { version -> create("org.jetbrains.dokka:$module:$version") }
 
     private fun AttributeContainer.dokkaPluginsClasspath() {
-      attribute(DokkatooFormatAttribute, formatDependencies.formatAttributes.format)
-      attribute(DokkatooClasspathAttribute, formatDependencies.baseAttributes.dokkaPlugins)
+      attribute(DokkatooFormatAttribute, formatDependencies.formatAttributes.format.name)
+      attribute(DokkatooClasspathAttribute, formatDependencies.baseAttributes.dokkaPlugins.name)
     }
 
     private fun AttributeContainer.dokkaGeneratorClasspath() {
-      attribute(DokkatooFormatAttribute, formatDependencies.formatAttributes.format)
-      attribute(DokkatooClasspathAttribute, formatDependencies.baseAttributes.dokkaGenerator)
+      attribute(DokkatooFormatAttribute, formatDependencies.formatAttributes.format.name)
+      attribute(DokkatooClasspathAttribute, formatDependencies.baseAttributes.dokkaGenerator.name)
     }
 
     /** Add a dependency to the Dokka plugins classpath */

--- a/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/internal/gradleUtils.kt
@@ -321,7 +321,7 @@ internal operator fun <T : Any> AttributeContainer.get(key: Attribute<T>): T? {
   )
 }
 
-/** Leniently check if [Attribute.type]s are equal, avoiding [Class.hashCode] classloader issues. */
+/** Leniently check if [Attribute.type]s are equal, avoiding [Class.hashCode] classloader differences. */
 private fun Attribute<*>.matchesTypeOf(other: Attribute<*>): Boolean {
   val thisTypeId = this.typeId() ?: false
   val otherTypeId = other.typeId() ?: false


### PR DESCRIPTION
- use `Attribute<String>` instead of typed attributes.
- change the Dokkatoo attributes to be value classes, so they can still be used mostly type-safely.
- Improve logging (include hashcodes) and error reporting.

Workaround for https://github.com/adamko-dev/dokkatoo/issues/214