### PR TITLE
Easier configuration of DokkaPublication output directory

### DIFF
--- a/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
+++ b/modules/dokkatoo-plugin/api/dokkatoo-plugin.api
@@ -68,6 +68,7 @@ public abstract class dev/adamko/dokkatoo/dokka/DokkaPublication : java/io/Seria
 	public fun getName ()Ljava/lang/String;
 	public abstract fun getOfflineMode ()Lorg/gradle/api/provider/Property;
 	public abstract fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getOutputDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getPluginsConfiguration ()Lorg/gradle/api/ExtensiblePolymorphicDomainObjectContainer;
 	public abstract fun getSuppressInheritedMembers ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSuppressObviousFunctions ()Lorg/gradle/api/provider/Property;

--- a/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/DokkatooBasePlugin.kt
@@ -136,13 +136,19 @@ constructor(
     dokkatooExtension.dokkatooPublications.all {
       enabled.convention(true)
       cacheRoot.convention(dokkatooExtension.dokkatooCacheDirectory)
+      @Suppress("DEPRECATION")
       delayTemplateSubstitution.convention(false)
       failOnWarning.convention(false)
       finalizeCoroutines.convention(false)
       moduleName.convention(dokkatooExtension.moduleName)
       moduleVersion.convention(dokkatooExtension.moduleVersion)
       offlineMode.convention(false)
-      outputDir.convention(dokkatooExtension.dokkatooPublicationDirectory)
+      outputDirectory.convention(
+        @Suppress("DEPRECATION")
+        outputDir
+          .orElse(dokkatooExtension.dokkatooPublicationDirectory.dir(formatName))
+      )
+      moduleOutputDirectory.convention(dokkatooExtension.dokkatooModuleDirectory.dir(formatName))
       suppressInheritedMembers.convention(false)
       suppressObviousFunctions.convention(true)
     }

--- a/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/dokka/DokkaPublication.kt
@@ -10,10 +10,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.*
-import org.gradle.api.tasks.PathSensitivity.RELATIVE
-import org.gradle.kotlin.dsl.*
 
 /**
  * A [DokkaPublication] describes a single Dokka output.
@@ -27,7 +23,6 @@ abstract class DokkaPublication
 @DokkatooInternalApi
 @Inject
 constructor(
-  @get:Internal
   val formatName: String,
 
   /**
@@ -38,79 +33,42 @@ constructor(
 ) : Named, Serializable, ExtensionAware {
 
   /** Configurations for Dokka Generator Plugins. */
-  @get:Nested
   val pluginsConfiguration: DokkaPluginParametersContainer =
     extensions.adding("pluginsConfiguration", pluginsConfiguration)
 
-  @Internal
   override fun getName(): String = formatName
 
-  @get:Input
   abstract val enabled: Property<Boolean>
 
-  @get:Input
   abstract val moduleName: Property<String>
 
-  @get:Input
-  @get:Optional
   abstract val moduleVersion: Property<String>
 
-  @get:Internal
-  // marked as Internal because this task does not use the directory contents, only the location
+  /** Renamed - use [outputDirectory] instead. */
+  @Deprecated("Renamed to outputDirectory", ReplaceWith("outputDirectory"))
   abstract val outputDir: DirectoryProperty
 
-  /**
-   * Because [outputDir] must be [Internal] (so Gradle doesn't check the directory contents),
-   * [outputDirPath] is required so Gradle can determine if the task is up-to-date.
-   */
-  @get:Input
-  // marked as an Input because a DokkaPublication is used to configure the appropriate
-  // DokkatooTasks, which will then
-  @DokkatooInternalApi
-  protected val outputDirPath: Provider<String>
-    get() = outputDir.map { it.asFile.invariantSeparatorsPath }
+  /** Output directory for the finished Dokka publication. */
+  abstract val outputDirectory: DirectoryProperty
 
-  @get:Internal
-  // Marked as Internal because this task does not use the directory contents, only the location.
-  // Note that `cacheRoot` is not used by Dokka, and will probably be deprecated.
+  /** Output directory for the partial Dokka module. */
+  internal abstract val moduleOutputDirectory: DirectoryProperty
+
   abstract val cacheRoot: DirectoryProperty
 
-  /**
-   * Because [cacheRoot] must be [Internal] (so Gradle doesn't check the directory contents),
-   * [cacheRootPath] is required so Gradle can determine if the task is up-to-date.
-   */
-  @get:Input
-  @get:Optional
-  @DokkatooInternalApi
-  protected val cacheRootPath: Provider<String>
-    get() = cacheRoot.map { it.asFile.invariantSeparatorsPath }
-
-  @get:Input
   abstract val offlineMode: Property<Boolean>
 
-//    /** Dokka Configuration files from other subprojects that will be merged into this Dokka Configuration */
-//    @get:InputFiles
-//    @get:NormalizeLineEndings
-//    @get:PathSensitive(PathSensitivity.NAME_ONLY)
-//    abstract val dokkaSubprojectConfigurations: ConfigurableFileCollection
-
-  @get:Input
   abstract val failOnWarning: Property<Boolean>
 
-  @get:Input
+  @Deprecated("No longer used")
   abstract val delayTemplateSubstitution: Property<Boolean>
 
-  @get:Input
   abstract val suppressObviousFunctions: Property<Boolean>
 
-  @get:InputFiles
-  @get:PathSensitive(RELATIVE)
   abstract val includes: ConfigurableFileCollection
 
-  @get:Input
   abstract val suppressInheritedMembers: Property<Boolean>
 
-  @get:Input
   // TODO probably not needed any more, since Dokka Generator now runs in an isolated JVM process
   abstract val finalizeCoroutines: Property<Boolean>
 }

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatPlugin.kt
@@ -79,7 +79,6 @@ abstract class DokkatooFormatPlugin(
       val dokkatooTasks = DokkatooFormatTasks(
         project = target,
         publication = publication,
-        dokkatooExtension = dokkatooExtension,
         formatDependencies = formatDependencies,
         providers = providers,
       )

--- a/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatTasks.kt
+++ b/modules/dokkatoo-plugin/src/main/kotlin/formats/DokkatooFormatTasks.kt
@@ -1,6 +1,5 @@
 package dev.adamko.dokkatoo.formats
 
-import dev.adamko.dokkatoo.DokkatooExtension
 import dev.adamko.dokkatoo.dependencies.FormatDependenciesManager
 import dev.adamko.dokkatoo.dokka.DokkaPublication
 import dev.adamko.dokkatoo.internal.DokkatooInternalApi
@@ -19,7 +18,6 @@ import org.gradle.kotlin.dsl.*
 class DokkatooFormatTasks(
   project: Project,
   private val publication: DokkaPublication,
-  private val dokkatooExtension: DokkatooExtension,
   private val formatDependencies: FormatDependenciesManager,
 
   private val providers: ProviderFactory,
@@ -57,7 +55,7 @@ class DokkatooFormatTasks(
     ).configuring {
       description = "Executes the Dokka Generator, generating the $formatName publication"
 
-      outputDirectory.convention(dokkatooExtension.dokkatooPublicationDirectory.dir(formatName))
+      outputDirectory.convention(publication.outputDirectory)
 
       applyFormatSpecificConfiguration()
     }
@@ -69,7 +67,7 @@ class DokkatooFormatTasks(
     ).configuring {
       description = "Executes the Dokka Generator, generating a $formatName module"
 
-      outputDirectory.convention(dokkatooExtension.dokkatooModuleDirectory.dir(formatName))
+      outputDirectory.convention(publication.moduleOutputDirectory)
 
       applyFormatSpecificConfiguration()
     }


### PR DESCRIPTION
- rename `outputDir` to `outputDirectory` for consistency.
- also add `moduleOutputDirectory`, so it's defined in one place.

Also:
- Remove unnecessary task input annotations from DokkaPublication - it's not used as a task input.
- Deprecate `delayTemplateSubstitution` - it's not used. The value is configured automatically by the Dokka tasks