### PR TITLE
Reduce stdout logging during tests

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
@@ -34,7 +34,6 @@ tasks.withType<AbstractTestTask>().configureEach {
       TestLogEvent.PASSED,
       TestLogEvent.FAILED,
       TestLogEvent.SKIPPED,
-      TestLogEvent.STARTED,
       TestLogEvent.STANDARD_ERROR,
       TestLogEvent.STANDARD_OUT,
     )

--- a/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
+++ b/modules/dokkatoo-plugin-integration-tests/build.gradle.kts
@@ -101,6 +101,13 @@ testing.suites {
           // workaround for lazy-properties not working https://github.com/gradle/gradle/issues/12247
           systemProperty("exampleProjectsDir", dokkatooExamplesDir.get())
         }
+
+        systemProperty(
+          "kotest.framework.config.fqn",
+          "dev.adamko.dokkatoo.utils.KotestProjectConfig",
+        )
+        // FIXME remove autoscan when Kotest >= 6.0
+        systemProperty("kotest.framework.classpath.scanning.autoscan.disable", "true")
       }
     }
   }
@@ -129,21 +136,6 @@ tasks.withType<Test>().configureEach {
   )
 
   mustRunAfter(tasks.withType<AbstractPublishToMaven>())
-
-  testLogging {
-    events = setOf(
-      TestLogEvent.STARTED,
-      TestLogEvent.PASSED,
-      TestLogEvent.SKIPPED,
-      TestLogEvent.FAILED,
-      TestLogEvent.STANDARD_OUT,
-      TestLogEvent.STANDARD_ERROR,
-    )
-    showStandardStreams = true
-    showExceptions = true
-    showCauses = true
-    showStackTraces = true
-  }
 }
 //endregion
 

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CompositeBuildExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CompositeBuildExampleTest.kt
@@ -26,7 +26,6 @@ class CompositeBuildExampleTest : FunSpec({
           ":build",
           "--stacktrace",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
         }
@@ -39,8 +38,9 @@ class CompositeBuildExampleTest : FunSpec({
       test("expect file trees are the same") {
         val expectedFileTree = exampleDataDir.toTreeString()
         val actualFileTree = dokkatooHtmlDir.toTreeString()
-        println((actualFileTree to expectedFileTree).sideBySide())
-        expectedFileTree shouldBe actualFileTree
+        withClue((actualFileTree to expectedFileTree).sideBySide()) {
+          expectedFileTree shouldBe actualFileTree
+        }
       }
 
       test("expect directories are the same") {
@@ -64,7 +64,6 @@ class CompositeBuildExampleTest : FunSpec({
           ":build",
           "--stacktrace",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
         }
@@ -75,7 +74,6 @@ class CompositeBuildExampleTest : FunSpec({
           "--stacktrace",
           "--build-cache",
         )
-        .forwardOutput()
         .build {
           output shouldContainAll listOf(
             "> Task :module-kakapo:dokkatooGenerateModuleHtml UP-TO-DATE",
@@ -105,7 +103,6 @@ class CompositeBuildExampleTest : FunSpec({
             "--no-build-cache",
             "--configuration-cache",
           )
-          .forwardOutput()
 
       test("first build should store the configuration cache") {
         configCacheRunner.build {

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/CustomFormatExampleTest.kt
@@ -32,7 +32,6 @@ class CustomFormatExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
           output shouldContain "Generation completed successfully"
@@ -47,7 +46,6 @@ class CustomFormatExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
 
@@ -67,9 +65,10 @@ class CustomFormatExampleTest : FunSpec({
       test("expect file trees are the same") {
         val expectedFileTree = dokkaHtmlDir.toTreeString()
         val actualFileTree = dokkatooHtmlDir.toTreeString()
-        println((actualFileTree to expectedFileTree).sideBySide())
-        // drop the first line from each, since the directory name is different
-        expectedFileTree.substringAfter("\n") shouldBe actualFileTree.substringAfter("\n")
+        withClue((actualFileTree to expectedFileTree).sideBySide()) {
+          // drop the first line from each, since the directory name is different
+          expectedFileTree.substringAfter("\n") shouldBe actualFileTree.substringAfter("\n")
+        }
       }
 
       test("expect directories are the same") {
@@ -89,7 +88,6 @@ class CustomFormatExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
 
@@ -108,7 +106,6 @@ class CustomFormatExampleTest : FunSpec({
           "--build-cache",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContainAll listOf(
             "> Task :dokkatooGeneratePublicationHtml UP-TO-DATE",
@@ -134,7 +131,6 @@ class CustomFormatExampleTest : FunSpec({
             "--no-build-cache",
             "--configuration-cache",
           )
-          .forwardOutput()
 
       test("first build should store the configuration cache") {
         configCacheRunner.build {

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/GradleExampleTest.kt
@@ -34,7 +34,6 @@ class GradleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
           output shouldContain "Generation completed successfully"
@@ -49,7 +48,6 @@ class GradleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
 
@@ -69,8 +67,9 @@ class GradleExampleTest : FunSpec({
       test("expect file trees are the same") {
         val expectedFileTree = dokkaHtmlDir.toTreeString()
         val actualFileTree = dokkatooHtmlDir.toTreeString()
-        println((actualFileTree to expectedFileTree).sideBySide())
-        expectedFileTree shouldBe actualFileTree
+        withClue((actualFileTree to expectedFileTree).sideBySide()) {
+          expectedFileTree shouldBe actualFileTree
+        }
       }
 
       test("expect directories are the same") {
@@ -90,7 +89,6 @@ class GradleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
 
@@ -110,7 +108,6 @@ class GradleExampleTest : FunSpec({
           "--info",
           "--build-cache",
         )
-        .forwardOutput()
         .build {
           output shouldContainAll listOf(
             "> Task :dokkatooGeneratePublicationHtml UP-TO-DATE",
@@ -136,7 +133,6 @@ class GradleExampleTest : FunSpec({
             "--no-build-cache",
             "--configuration-cache",
           )
-          .forwardOutput()
 
       test("first build should store the configuration cache") {
         configCacheRunner.build {

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/JavaExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/JavaExampleTest.kt
@@ -26,7 +26,6 @@ class JavaExampleTest : FunSpec({
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
         }
@@ -39,8 +38,9 @@ class JavaExampleTest : FunSpec({
       test("expect file trees are the same") {
         val expectedFileTree = exampleDataDir.toTreeString()
         val actualFileTree = dokkatooHtmlDir.toTreeString()
-        println((actualFileTree to expectedFileTree).sideBySide())
-        expectedFileTree shouldBe actualFileTree
+        withClue((actualFileTree to expectedFileTree).sideBySide()) {
+          expectedFileTree shouldBe actualFileTree
+        }
       }
 
       test("expect directories are the same") {
@@ -64,7 +64,6 @@ class JavaExampleTest : FunSpec({
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
         }
@@ -75,7 +74,6 @@ class JavaExampleTest : FunSpec({
           "--stacktrace",
           "--build-cache",
         )
-        .forwardOutput()
         .build {
           output shouldContainAll listOf(
             "> Task :my-java-application:dokkatooGenerateModuleHtml UP-TO-DATE",
@@ -106,7 +104,6 @@ class JavaExampleTest : FunSpec({
             "--no-build-cache",
             "--configuration-cache",
           )
-          .forwardOutput()
 
       test("first build should store the configuration cache") {
         configCacheRunner.build {

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/KotlinMultiplatformExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/KotlinMultiplatformExampleTest.kt
@@ -31,7 +31,6 @@ class KotlinMultiplatformExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
           output shouldContain "Generation completed successfully"
@@ -46,7 +45,6 @@ class KotlinMultiplatformExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           test("expect build is successful") {
             output shouldContain "BUILD SUCCESSFUL"
@@ -74,8 +72,9 @@ class KotlinMultiplatformExampleTest : FunSpec({
       test("expect file trees are the same") {
         val expectedFileTree = dokkaHtmlDir.toTreeString()
         val actualFileTree = dokkatooHtmlDir.toTreeString()
-        println((actualFileTree to expectedFileTree).sideBySide())
-        expectedFileTree shouldBe actualFileTree
+        withClue((actualFileTree to expectedFileTree).sideBySide()) {
+          expectedFileTree shouldBe actualFileTree
+        }
       }
 
       test("expect directories are the same") {
@@ -95,7 +94,6 @@ class KotlinMultiplatformExampleTest : FunSpec({
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
         )
-        .forwardOutput()
         .build {
           test("expect build is successful") {
             output shouldContain "BUILD SUCCESSFUL"
@@ -122,7 +120,6 @@ class KotlinMultiplatformExampleTest : FunSpec({
             "--info",
             "--build-cache",
           )
-          .forwardOutput()
           .build {
 
             output shouldContainAll listOf(
@@ -150,7 +147,6 @@ class KotlinMultiplatformExampleTest : FunSpec({
             "--no-build-cache",
             "--configuration-cache",
           )
-          .forwardOutput()
 
       test("first build should store the configuration cache") {
         configCacheRunner.build {

--- a/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testExamples/kotlin/MultimoduleExampleTest.kt
@@ -3,6 +3,7 @@ package dev.adamko.dokkatoo.tests.examples
 import dev.adamko.dokkatoo.internal.DokkatooConstants.DOKKA_VERSION
 import dev.adamko.dokkatoo.utils.*
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.shouldForAll
 import io.kotest.matchers.collections.shouldHaveSize
@@ -34,7 +35,6 @@ class MultimoduleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           output shouldContain "BUILD SUCCESSFUL"
           output shouldContain "Generation completed successfully"
@@ -49,7 +49,6 @@ class MultimoduleExampleTest : FunSpec({
           "--stacktrace",
           "--info",
         )
-        .forwardOutput()
         .build {
           test("expect build is successful") {
             output shouldContain "BUILD SUCCESSFUL"
@@ -77,8 +76,9 @@ class MultimoduleExampleTest : FunSpec({
       test("expect file trees are the same") {
         val expectedFileTree = dokkaHtmlDir.toTreeString()
         val actualFileTree = dokkatooHtmlDir.toTreeString()
-        println((actualFileTree to expectedFileTree).sideBySide())
-        expectedFileTree shouldBe actualFileTree
+        withClue((actualFileTree to expectedFileTree).sideBySide()) {
+          expectedFileTree shouldBe actualFileTree
+        }
       }
 
       test("expect directories are the same") {
@@ -98,7 +98,6 @@ class MultimoduleExampleTest : FunSpec({
           ":parentProject:dokkatooGeneratePublicationHtml",
           "--stacktrace",
         )
-        .forwardOutput()
         .build {
           test("expect first build is successful") {
             output shouldContain "BUILD SUCCESSFUL"
@@ -124,7 +123,6 @@ class MultimoduleExampleTest : FunSpec({
           "--info",
           "--build-cache",
         )
-        .forwardOutput()
         .build {
           test("expect second build is successful") {
             output shouldContain "BUILD SUCCESSFUL"
@@ -160,7 +158,6 @@ class MultimoduleExampleTest : FunSpec({
             "--no-build-cache",
             "--configuration-cache",
           )
-          .forwardOutput()
 
       test("first build should store the configuration cache") {
         configCacheRunner.build {

--- a/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin-integration-tests/src/testIntegration/kotlin/BasicProjectIntegrationTest.kt
@@ -2,6 +2,7 @@ package dev.adamko.dokkatoo.tests.integration
 
 import dev.adamko.dokkatoo.utils.*
 import dev.adamko.dokkatoo.utils.GradleProjectTest.Companion.projectTestTempDir
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.file.shouldBeAFile
 import io.kotest.matchers.file.shouldHaveSameStructureAndContentAs
@@ -30,7 +31,6 @@ class BasicProjectIntegrationTest : FunSpec({
         "dokkaHtml",
         "--stacktrace",
       )
-      .forwardOutput()
       .build {
         context("with Dokka") {
           test("expect project builds successfully") {
@@ -45,7 +45,6 @@ class BasicProjectIntegrationTest : FunSpec({
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",
       )
-      .forwardOutput()
       .build {
         context("with Dokkatoo") {
           test("expect project builds successfully") {
@@ -73,11 +72,11 @@ class BasicProjectIntegrationTest : FunSpec({
 
       val expectedFileTree = dokkaHtmlDir.toTreeString()
       val actualFileTree = dokkatooHtmlDir.toTreeString()
-      println((actualFileTree to expectedFileTree).sideBySide())
-      expectedFileTree shouldBe actualFileTree
-
-      dokkatooHtmlDir.toFile().shouldHaveSameStructureAs(dokkaHtmlDir.toFile())
-      dokkatooHtmlDir.toFile().shouldHaveSameStructureAndContentAs(dokkaHtmlDir.toFile())
+      withClue((actualFileTree to expectedFileTree).sideBySide()) {
+        expectedFileTree shouldBe actualFileTree
+        dokkatooHtmlDir.toFile().shouldHaveSameStructureAs(dokkaHtmlDir.toFile())
+        dokkatooHtmlDir.toFile().shouldHaveSameStructureAndContentAs(dokkaHtmlDir.toFile())
+      }
     }
 
     test("Dokkatoo tasks should be cacheable") {
@@ -87,7 +86,6 @@ class BasicProjectIntegrationTest : FunSpec({
           "--stacktrace",
           "--build-cache",
         )
-        .forwardOutput()
         .build {
           output shouldContainAll listOf(
             "Task :dokkatooGeneratePublicationHtml UP-TO-DATE",
@@ -108,7 +106,6 @@ class BasicProjectIntegrationTest : FunSpec({
             "--no-build-cache",
             "--configuration-cache",
           )
-          .forwardOutput()
 
       test("first build should store the configuration cache") {
         configCacheRunner.build {

--- a/modules/dokkatoo-plugin/build.gradle.kts
+++ b/modules/dokkatoo-plugin/build.gradle.kts
@@ -142,6 +142,13 @@ testing.suites {
             // depend on the test-publication task, but not the test-maven repo
             // (otherwise this task will never be up-to-date)
             dependsOn(tasks.publishToTestMavenRepo)
+
+            systemProperty(
+              "kotest.framework.config.fqn",
+              "dev.adamko.dokkatoo.utils.KotestProjectConfig",
+            )
+            // FIXME remove autoscan when Kotest >= 6.0
+            systemProperty("kotest.framework.classpath.scanning.autoscan.disable", "true")
           }
         }
       }

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/KotestProjectConfig.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/KotestProjectConfig.kt
@@ -2,7 +2,7 @@ package dev.adamko.dokkatoo.utils
 
 import io.kotest.core.config.AbstractProjectConfig
 
-@Suppress("unused") // this class is automatically picked up by Kotest
+@Suppress("unused") // Kotest loads this class via system property `kotest.framework.config.fqn`
 object KotestProjectConfig : AbstractProjectConfig() {
   init {
     displayFullTestPath = true

--- a/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
+++ b/modules/dokkatoo-plugin/src/testFixtures/kotlin/gradleRunnerUtils.kt
@@ -1,5 +1,6 @@
 package dev.adamko.dokkatoo.utils
 
+import io.kotest.assertions.withClue
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.GradleRunner
@@ -17,12 +18,20 @@ fun GradleRunner.withEnvironment(build: MutableMap<String, String?>.() -> Unit):
 
 inline fun GradleRunner.build(
   handleResult: BuildResult.() -> Unit
-): Unit = build().let(handleResult)
+): Unit = build().let {
+  withClue({ it.output.prependIndent() }) {
+    handleResult(it)
+  }
+}
 
 
 inline fun GradleRunner.buildAndFail(
   handleResult: BuildResult.() -> Unit
-): Unit = buildAndFail().let(handleResult)
+): Unit = buildAndFail().let {
+  withClue({ it.output.prependIndent() }) {
+    handleResult(it)
+  }
+}
 
 
 fun GradleRunner.withJvmArguments(

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/AttributeHackTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/AttributeHackTest.kt
@@ -17,7 +17,6 @@ class AttributeHackTest : FunSpec({
         "--stacktrace",
         "--no-configuration-cache",
       )
-      .forwardOutput()
       .build {
         test("resolving JARs from a Dokkatoo-enabled project should not contain Dokka plugin JARs") {
           output.shouldNotContainAnyOf(

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/DuplicateModulePathWarningTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/DuplicateModulePathWarningTest.kt
@@ -37,7 +37,6 @@ class DuplicateModulePathWarningTest : FunSpec({
           "--stacktrace",
           "--warn",
         )
-        .forwardOutput()
         .build {
           test("expect duplicate module path warning") {
             output.shouldContainAll(

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/GradlePluginProjectIntegrationTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/GradlePluginProjectIntegrationTest.kt
@@ -20,7 +20,6 @@ class GradlePluginProjectIntegrationTest : FunSpec({
         "dokkatooGeneratePublicationHtml",
         "--stacktrace",
       )
-      .forwardOutput()
       .build {
 
         test("expect project builds successfully") {

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/HtmlAggregationWarningTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/HtmlAggregationWarningTest.kt
@@ -28,7 +28,6 @@ class HtmlAggregationWarningTest : FunSpec({
         "--stacktrace",
         "--info",
       )
-      .forwardOutput()
       .build {
         test("expect warning message is logged") {
           output shouldContain expectedWarning
@@ -47,7 +46,6 @@ class HtmlAggregationWarningTest : FunSpec({
         "--stacktrace",
         "--info",
       )
-      .forwardOutput()
       .build {
         test("expect warning message is not logged") {
           output shouldNotContain expectedWarning

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinDslAccessorsTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinDslAccessorsTest.kt
@@ -14,7 +14,6 @@ class KotlinDslAccessorsTest : FunSpec({
 
     project
       .runner
-      .forwardOutput()
       .addArguments(
         ":clean",
         ":compileKotlin",

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinMultiplatformFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/KotlinMultiplatformFunctionalTest.kt
@@ -24,7 +24,6 @@ class KotlinMultiplatformFunctionalTest : FunSpec({
         ":dokkatooGeneratePublicationHtml",
         "--stacktrace",
       )
-      .forwardOutput()
       .build {
         test("expect build is successful") {
           output shouldContain "BUILD SUCCESSFUL"

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -34,7 +34,6 @@ class MultiModuleFunctionalTest : FunSpec({
         ":dokkatooGenerate",
         "--stacktrace",
       )
-      .forwardOutput()
       .build {
         test("expect build is successful") {
           output shouldContain "BUILD SUCCESSFUL"
@@ -115,7 +114,6 @@ class MultiModuleFunctionalTest : FunSpec({
           "--stacktrace",
           "--build-cache",
         )
-        .forwardOutput()
         .build {
           test("expect build is successful") {
             output shouldContain "BUILD SUCCESSFUL"
@@ -141,7 +139,6 @@ class MultiModuleFunctionalTest : FunSpec({
             "--stacktrace",
             "--build-cache",
           )
-          .forwardOutput()
           .build {
             test("expect build is successful") {
               output shouldContainAll listOf(
@@ -224,7 +221,6 @@ class MultiModuleFunctionalTest : FunSpec({
             "clean",
             "--build-cache",
           )
-          .forwardOutput()
           .build {
             test("clean tasks should run successfully") {
               shouldHaveTasksWithAnyOutcome(
@@ -243,7 +239,6 @@ class MultiModuleFunctionalTest : FunSpec({
             "--build-cache",
             "-D" + "org.gradle.caching.debug=true"
           )
-          .forwardOutput()
           .build {
             test("should execute all generation tasks") {
               shouldHaveTasksWithOutcome(expectedGenerationTasks.map { it to SUCCESS })
@@ -257,7 +252,6 @@ class MultiModuleFunctionalTest : FunSpec({
             "clean",
             "--build-cache",
           )
-          .forwardOutput()
           .build {
             test("clean tasks should run successfully") {
               shouldHaveTasksWithAnyOutcome(
@@ -275,7 +269,6 @@ class MultiModuleFunctionalTest : FunSpec({
             "--build-cache",
             "-D" + "org.gradle.caching.debug=true"
           )
-          .forwardOutput()
           .build {
             test("should load all generation tasks from cache") {
               shouldHaveTasksWithOutcome(expectedGenerationTasks.map { it to FROM_CACHE })
@@ -302,7 +295,6 @@ class MultiModuleFunctionalTest : FunSpec({
           "--no-build-cache",
           "--configuration-cache",
         )
-        .forwardOutput()
         .build {
           test("expect build is successful") {
             output shouldContain "BUILD SUCCESSFUL"
@@ -341,7 +333,6 @@ class MultiModuleFunctionalTest : FunSpec({
             "--stacktrace",
             "--build-cache",
           )
-          .forwardOutput()
           .build {
             output shouldContain "BUILD SUCCESSFUL"
           }
@@ -372,7 +363,6 @@ class MultiModuleFunctionalTest : FunSpec({
               "--stacktrace",
               "--build-cache",
             )
-            .forwardOutput()
             .build {
 
               test("expect HelloAgain HTML file exists") {
@@ -422,7 +412,6 @@ class MultiModuleFunctionalTest : FunSpec({
                 "--info",
                 "--build-cache",
               )
-              .forwardOutput()
               .build {
 
                 test("expect HelloAgain HTML file is now deleted") {
@@ -455,7 +444,6 @@ class MultiModuleFunctionalTest : FunSpec({
           "--no-build-cache",
           "--quiet",
         )
-        .forwardOutput()
         .build {
           output.shouldBeEmpty()
         }
@@ -471,7 +459,6 @@ class MultiModuleFunctionalTest : FunSpec({
           "--no-parallel",
           // no logging option => lifecycle log level
         )
-        .forwardOutput()
         .build {
 
           // projects are only configured the first time TestKit runs, and annoyingly there's no
@@ -527,7 +514,6 @@ class MultiModuleFunctionalTest : FunSpec({
     test("expect warning regarding KotlinProjectExtension") {
       project.runner
         .addArguments("clean")
-        .forwardOutput()
         .build {
           // the root project doesn't have the KGP applied, so KotlinProjectExtension shouldn't be applied
           output shouldNotContain "DokkatooKotlinAdapter failed to get KotlinProjectExtension in :\n"
@@ -603,7 +589,6 @@ class MultiModuleFunctionalTest : FunSpec({
           ":dokkatooGeneratePublicationHtml",
           "--stacktrace",
         )
-        .forwardOutput()
         .build {
 
           test("expect project builds successfully") {

--- a/modules/dokkatoo-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
+++ b/modules/dokkatoo-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
@@ -33,7 +33,6 @@ class LogHtmlPublicationLinkTaskTest : FunSpec({
             "--info",
             validServerUriParam,
           )
-          .forwardOutput()
           .build {
             test("expect project builds successfully") {
               output shouldContain "BUILD SUCCESSFUL"
@@ -62,7 +61,6 @@ class LogHtmlPublicationLinkTaskTest : FunSpec({
               "--info",
               validServerUriParam,
             )
-            .forwardOutput()
             .build {
               test("expect project builds successfully") {
                 output shouldContain "BUILD SUCCESSFUL"


### PR DESCRIPTION
- Avoid forwarding Gradle TestKit logs, unless the test fails.
- Fix Kotest classpath scan warning.
- Don't log 'test started' events